### PR TITLE
Fix OHLC open/close

### DIFF
--- a/clickhouse-solana-dex/examples/OHLC Prices.sql
+++ b/clickhouse-solana-dex/examples/OHLC Prices.sql
@@ -43,8 +43,8 @@ LIMIT 10;
 -- Minimal OHLC Prices --
 SELECT
       timestamp,
-      argMinMerge(open0) * 1000) AS open * 1000,
-      argMaxMerge(close0) AS close * 1000
+      argMinMerge(open0) * 1000 AS open,
+      argMaxMerge(close0) * 1000 AS close
 FROM ohlc_prices
 WHERE amm_pool = '58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2' -- Raydium V4 WSOL/USDC
 GROUP BY amm_pool, timestamp

--- a/clickhouse-solana-dex/schema.0.functions.helpers.sql
+++ b/clickhouse-solana-dex/schema.0.functions.helpers.sql
@@ -1,0 +1,2 @@
+CREATE FUNCTION IF NOT EXISTS to_version AS (block_num, transaction_index, instruction_index) ->
+    block_num * 1e6 + transaction_index * 1e3 + instruction_index;

--- a/clickhouse-solana-dex/schema.3.view.ohlc_prices.sql
+++ b/clickhouse-solana-dex/schema.3.view.ohlc_prices.sql
@@ -66,17 +66,17 @@ WITH
     if(dir, toInt128(input_amount), -toInt128(output_amount))  AS nf0,
     -- net flow of mint1: +in, -out (signs flipped vs. your original)
     if(dir, -toInt128(output_amount), toInt128(input_amount))  AS nf1,
-    timestamp AS ts_event,
-    toUInt64(timestamp) AS ts64
+    -- version is used to determine min/max states --
+    toUInt64(to_version(block_num, transaction_index, instruction_index)) AS version
 
 SELECT
-    toStartOfHour(ts_event)    AS timestamp,
+    toStartOfHour(swaps.timestamp)    AS timestamp,
     program_id, amm, amm_pool, mint0, mint1,
 
     /* OHLC */
-    argMinState(price, ts64)                 AS open0,
-    quantileDeterministicState(price, ts64)  AS quantile0,
-    argMaxState(price, ts64)                 AS close0,
+    argMinState(price, version)                 AS open0,
+    quantileDeterministicState(price, version)  AS quantile0,
+    argMaxState(price, version)                 AS close0,
 
     /* volumes & flows (all in canonical orientation) */
     sum(gv0)                AS gross_volume0,

--- a/clickhouse-solana-dex/substreams.yaml
+++ b/clickhouse-solana-dex/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: solana_dex
-  version: v0.2.7
+  version: v0.2.8
   url: https://github.com/pinax-network/substreams-solana
   description: DEXs for Solana.
   image: ../image.png


### PR DESCRIPTION
`timestamp` was being mutated

Solution: Switched to using `version` (block + index ordering)

```sql
/* OHLC */
argMinState(price, version)                 AS open0,
quantileDeterministicState(price, version)  AS quantile0,
argMaxState(price, version)                 AS close0,
```

<img width="1052" height="704" alt="image" src="https://github.com/user-attachments/assets/ce035a54-e738-4e9f-ad25-9954abae8535" />
