### PR TITLE
feat: add raydium launchpad substreams crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "jupiter-v4",
   "jupiter-v6",
   "raydium-amm-v4",
+  "raydium-launchpad",
   "metaplex",
 
   # # General

--- a/proto/src/pb/mod.rs
+++ b/proto/src/pb/mod.rs
@@ -28,6 +28,13 @@ pub mod raydium {
             // @@protoc_insertion_point(raydium.amm.v1)
         }
     }
+    pub mod launchpad {
+        // @@protoc_insertion_point(attribute:raydium.launchpad.v1)
+        pub mod v1 {
+            include!("raydium.launchpad.v1.rs");
+            // @@protoc_insertion_point(raydium.launchpad.v1)
+        }
+    }
 }
 pub mod solana {
     pub mod metaplex {

--- a/proto/src/pb/raydium.launchpad.v1.rs
+++ b/proto/src/pb/raydium.launchpad.v1.rs
@@ -1,0 +1,204 @@
+#[allow(clippy::all)]
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(dead_code)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Events {
+    #[prost(message, repeated, tag="1")]
+    pub transactions: ::prost::alloc::vec::Vec<Transaction>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Transaction {
+    #[prost(bytes="vec", tag="1")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub fee_payer: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", repeated, tag="3")]
+    pub signers: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(uint64, tag="4")]
+    pub fee: u64,
+    #[prost(uint64, tag="5")]
+    pub compute_units_consumed: u64,
+    #[prost(message, repeated, tag="6")]
+    pub instructions: ::prost::alloc::vec::Vec<Instruction>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Instruction {
+    #[prost(bytes="vec", tag="1")]
+    pub program_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint32, tag="2")]
+    pub stack_height: u32,
+    #[prost(oneof="instruction::Instruction", tags="3, 4, 5, 6, 7")]
+    pub instruction: ::core::option::Option<instruction::Instruction>,
+}
+/// Nested message and enum types in `Instruction`.
+pub mod instruction {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Instruction {
+        #[prost(message, tag="3")]
+        BuyExactIn(super::BuyExactInInstruction),
+        #[prost(message, tag="4")]
+        BuyExactOut(super::BuyExactOutInstruction),
+        #[prost(message, tag="5")]
+        SellExactIn(super::SellExactInInstruction),
+        #[prost(message, tag="6")]
+        SellExactOut(super::SellExactOutInstruction),
+        #[prost(message, tag="7")]
+        TradeEvent(super::TradeEvent),
+    }
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TradeAccounts {
+    #[prost(bytes="vec", tag="1")]
+    pub payer: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub authority: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="3")]
+    pub global_config: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub platform_config: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="5")]
+    pub pool_state: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="6")]
+    pub user_base_token: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="7")]
+    pub user_quote_token: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="8")]
+    pub base_vault: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="9")]
+    pub quote_vault: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="10")]
+    pub base_token_mint: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="11")]
+    pub quote_token_mint: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="12")]
+    pub base_token_program: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="13")]
+    pub quote_token_program: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="14")]
+    pub event_authority: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="15")]
+    pub program: ::prost::alloc::vec::Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BuyExactInInstruction {
+    #[prost(message, optional, tag="1")]
+    pub accounts: ::core::option::Option<TradeAccounts>,
+    #[prost(uint64, tag="2")]
+    pub amount_in: u64,
+    #[prost(uint64, tag="3")]
+    pub minimum_amount_out: u64,
+    #[prost(uint64, tag="4")]
+    pub share_fee_rate: u64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BuyExactOutInstruction {
+    #[prost(message, optional, tag="1")]
+    pub accounts: ::core::option::Option<TradeAccounts>,
+    #[prost(uint64, tag="2")]
+    pub amount_out: u64,
+    #[prost(uint64, tag="3")]
+    pub maximum_amount_in: u64,
+    #[prost(uint64, tag="4")]
+    pub share_fee_rate: u64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SellExactInInstruction {
+    #[prost(message, optional, tag="1")]
+    pub accounts: ::core::option::Option<TradeAccounts>,
+    #[prost(uint64, tag="2")]
+    pub amount_in: u64,
+    #[prost(uint64, tag="3")]
+    pub minimum_amount_out: u64,
+    #[prost(uint64, tag="4")]
+    pub share_fee_rate: u64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SellExactOutInstruction {
+    #[prost(message, optional, tag="1")]
+    pub accounts: ::core::option::Option<TradeAccounts>,
+    #[prost(uint64, tag="2")]
+    pub amount_out: u64,
+    #[prost(uint64, tag="3")]
+    pub maximum_amount_in: u64,
+    #[prost(uint64, tag="4")]
+    pub share_fee_rate: u64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TradeEvent {
+    #[prost(bytes="vec", tag="1")]
+    pub pool_state: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag="2")]
+    pub total_base_sell: u64,
+    #[prost(uint64, tag="3")]
+    pub virtual_base: u64,
+    #[prost(uint64, tag="4")]
+    pub virtual_quote: u64,
+    #[prost(uint64, tag="5")]
+    pub real_base_before: u64,
+    #[prost(uint64, tag="6")]
+    pub real_quote_before: u64,
+    #[prost(uint64, tag="7")]
+    pub real_base_after: u64,
+    #[prost(uint64, tag="8")]
+    pub real_quote_after: u64,
+    #[prost(uint64, tag="9")]
+    pub amount_in: u64,
+    #[prost(uint64, tag="10")]
+    pub amount_out: u64,
+    #[prost(uint64, tag="11")]
+    pub protocol_fee: u64,
+    #[prost(uint64, tag="12")]
+    pub platform_fee: u64,
+    #[prost(uint64, tag="13")]
+    pub creator_fee: u64,
+    #[prost(uint64, tag="14")]
+    pub share_fee: u64,
+    #[prost(enumeration="TradeDirection", tag="15")]
+    pub trade_direction: i32,
+    #[prost(enumeration="PoolStatus", tag="16")]
+    pub pool_status: i32,
+    #[prost(bool, tag="17")]
+    pub exact_in: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum TradeDirection {
+    Buy = 0,
+    Sell = 1,
+}
+impl TradeDirection {
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            TradeDirection::Buy => "BUY",
+            TradeDirection::Sell => "SELL",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum PoolStatus {
+    Fund = 0,
+    Migrate = 1,
+    Trade = 2,
+}
+impl PoolStatus {
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            PoolStatus::Fund => "FUND",
+            PoolStatus::Migrate => "MIGRATE",
+            PoolStatus::Trade => "TRADE",
+        }
+    }
+}
+

--- a/proto/substreams.yaml
+++ b/proto/substreams.yaml
@@ -12,6 +12,7 @@ protobuf:
     - v1/jupiter.proto
     - v1/raydium-amm.proto
     - v1/metaplex.proto
+    - v1/raydium-launchpad.proto
   excludePaths:
     - sf/substreams
     - sf/solana

--- a/proto/v1/raydium-launchpad.proto
+++ b/proto/v1/raydium-launchpad.proto
@@ -1,0 +1,116 @@
+syntax = "proto3";
+
+package raydium.launchpad.v1;
+
+// -----------------------------------------------------------------------------
+// Top-level containers
+// -----------------------------------------------------------------------------
+message Events {
+  repeated Transaction transactions = 1;
+}
+
+message Transaction {
+  bytes signature                   = 1;
+  bytes fee_payer                   = 2;
+  repeated bytes signers            = 3;
+  uint64 fee                        = 4;
+  uint64 compute_units_consumed     = 5;
+  repeated Instruction instructions = 6;
+}
+
+// -----------------------------------------------------------------------------
+// Instruction + typed payloads
+// -----------------------------------------------------------------------------
+message Instruction {
+  bytes  program_id = 1;
+  uint32 stack_height = 2;
+  oneof instruction {
+    BuyExactInInstruction buy_exact_in     = 3;
+    BuyExactOutInstruction buy_exact_out   = 4;
+    SellExactInInstruction sell_exact_in   = 5;
+    SellExactOutInstruction sell_exact_out = 6;
+    TradeEvent trade_event                 = 7;
+  }
+}
+
+// Accounts shared by trade instructions
+message TradeAccounts {
+  bytes payer               = 1;
+  bytes authority           = 2;
+  bytes global_config       = 3;
+  bytes platform_config     = 4;
+  bytes pool_state          = 5;
+  bytes user_base_token     = 6;
+  bytes user_quote_token    = 7;
+  bytes base_vault          = 8;
+  bytes quote_vault         = 9;
+  bytes base_token_mint     = 10;
+  bytes quote_token_mint    = 11;
+  bytes base_token_program  = 12;
+  bytes quote_token_program = 13;
+  bytes event_authority     = 14;
+  bytes program             = 15;
+}
+
+message BuyExactInInstruction {
+  TradeAccounts accounts = 1;
+  uint64 amount_in = 2;
+  uint64 minimum_amount_out = 3;
+  uint64 share_fee_rate = 4;
+}
+
+message BuyExactOutInstruction {
+  TradeAccounts accounts = 1;
+  uint64 amount_out = 2;
+  uint64 maximum_amount_in = 3;
+  uint64 share_fee_rate = 4;
+}
+
+message SellExactInInstruction {
+  TradeAccounts accounts = 1;
+  uint64 amount_in = 2;
+  uint64 minimum_amount_out = 3;
+  uint64 share_fee_rate = 4;
+}
+
+message SellExactOutInstruction {
+  TradeAccounts accounts = 1;
+  uint64 amount_out = 2;
+  uint64 maximum_amount_in = 3;
+  uint64 share_fee_rate = 4;
+}
+
+// -----------------------------------------------------------------------------
+// Trade Event
+// -----------------------------------------------------------------------------
+message TradeEvent {
+  bytes pool_state       = 1;
+  uint64 total_base_sell = 2;
+  uint64 virtual_base    = 3;
+  uint64 virtual_quote   = 4;
+  uint64 real_base_before  = 5;
+  uint64 real_quote_before = 6;
+  uint64 real_base_after   = 7;
+  uint64 real_quote_after  = 8;
+  uint64 amount_in       = 9;
+  uint64 amount_out      = 10;
+  uint64 protocol_fee    = 11;
+  uint64 platform_fee    = 12;
+  uint64 creator_fee     = 13;
+  uint64 share_fee       = 14;
+  TradeDirection trade_direction = 15;
+  PoolStatus pool_status        = 16;
+  bool exact_in           = 17;
+}
+
+enum TradeDirection {
+  BUY = 0;
+  SELL = 1;
+}
+
+enum PoolStatus {
+  FUND    = 0;
+  MIGRATE = 1;
+  TRADE   = 2;
+}
+

--- a/raydium-launchpad/Cargo.toml
+++ b/raydium-launchpad/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "raydium_launchpad"
+description = "Raydium Launchpad"
+edition = { workspace = true }
+version = { workspace = true }
+authors = ["Denis <denis@pinax.network>"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+substreams = { workspace = true }
+substreams-solana = { workspace = true }
+proto = { path = "../proto" }
+common = { path = "../common" }
+carbon-raydium-launchpad-decoder = "0.9.1"
+solana-instruction-v2 = { package = "solana-instruction", version = "=2.2.1" }
+solana-pubkey-v2 = { package = "solana-pubkey", version = "=2.2.1", features = ["serde", "borsh", "curve25519"] }
+

--- a/raydium-launchpad/README.md
+++ b/raydium-launchpad/README.md
@@ -1,0 +1,4 @@
+# Raydium Launchpad
+
+Substreams module to decode Raydium Launchpad trades and events.
+

--- a/raydium-launchpad/src/lib.rs
+++ b/raydium-launchpad/src/lib.rs
@@ -1,0 +1,204 @@
+use carbon_raydium_launchpad_decoder::{
+    instructions::{
+        self, buy_exact_in, buy_exact_out, sell_exact_in, sell_exact_out,
+        RaydiumLaunchpadInstruction,
+    },
+    types::{pool_status::PoolStatus, trade_direction::TradeDirection},
+    RaydiumLaunchpadDecoder,
+};
+use common::solana::{get_fee_payer, get_signers};
+use proto::pb::raydium::launchpad::v1 as pb;
+use solana_instruction_v2::{AccountMeta, Instruction};
+use solana_pubkey_v2::Pubkey;
+use substreams::errors::Error;
+use substreams_solana::{
+    block_view::InstructionView,
+    pb::sf::solana::r#type::v1::{Block, ConfirmedTransaction},
+};
+
+#[substreams::handlers::map]
+fn map_events(block: Block) -> Result<pb::Events, Error> {
+    Ok(pb::Events {
+        transactions: block.transactions_owned().filter_map(process_transaction).collect(),
+    })
+}
+
+fn process_transaction(tx: ConfirmedTransaction) -> Option<pb::Transaction> {
+    let instructions: Vec<pb::Instruction> =
+        tx.walk_instructions().filter_map(|iv| process_instruction(&iv)).collect();
+    if instructions.is_empty() {
+        return None;
+    }
+
+    Some(pb::Transaction {
+        fee: tx.meta.as_ref()?.fee,
+        compute_units_consumed: tx.meta.as_ref()?.compute_units_consumed(),
+        signature: tx.hash().to_vec(),
+        fee_payer: get_fee_payer(&tx).unwrap_or_default(),
+        signers: get_signers(&tx).unwrap_or_default(),
+        instructions,
+    })
+}
+
+fn process_instruction(iv: &InstructionView) -> Option<pb::Instruction> {
+    let accounts: Vec<AccountMeta> = iv
+        .accounts()
+        .iter()
+        .map(|a| AccountMeta {
+            pubkey: Pubkey::new(a.0),
+            is_signer: a.1,
+            is_writable: a.2,
+        })
+        .collect();
+
+    let instruction = Instruction {
+        program_id: Pubkey::new(iv.program_id().0),
+        accounts: accounts.clone(),
+        data: iv.data().to_vec(),
+    };
+
+    let decoder = RaydiumLaunchpadDecoder;
+    let decoded = decoder.decode_instruction(&instruction)?;
+
+    let stack_height = iv.stack_height();
+
+    use RaydiumLaunchpadInstruction as RI;
+    let instruction = match decoded.data {
+        RI::BuyExactIn(data) => {
+            let acc = buy_exact_in::BuyExactIn::arrange_accounts(&accounts)?;
+            pb::instruction::Instruction::BuyExactIn(pb::BuyExactInInstruction {
+                accounts: Some(pb::TradeAccounts {
+                    payer: acc.payer.to_bytes().to_vec(),
+                    authority: acc.authority.to_bytes().to_vec(),
+                    global_config: acc.global_config.to_bytes().to_vec(),
+                    platform_config: acc.platform_config.to_bytes().to_vec(),
+                    pool_state: acc.pool_state.to_bytes().to_vec(),
+                    user_base_token: acc.user_base_token.to_bytes().to_vec(),
+                    user_quote_token: acc.user_quote_token.to_bytes().to_vec(),
+                    base_vault: acc.base_vault.to_bytes().to_vec(),
+                    quote_vault: acc.quote_vault.to_bytes().to_vec(),
+                    base_token_mint: acc.base_token_mint.to_bytes().to_vec(),
+                    quote_token_mint: acc.quote_token_mint.to_bytes().to_vec(),
+                    base_token_program: acc.base_token_program.to_bytes().to_vec(),
+                    quote_token_program: acc.quote_token_program.to_bytes().to_vec(),
+                    event_authority: acc.event_authority.to_bytes().to_vec(),
+                    program: acc.program.to_bytes().to_vec(),
+                }),
+                amount_in: data.amount_in,
+                minimum_amount_out: data.minimum_amount_out,
+                share_fee_rate: data.share_fee_rate,
+            })
+        }
+        RI::BuyExactOut(data) => {
+            let acc = buy_exact_out::BuyExactOut::arrange_accounts(&accounts)?;
+            pb::instruction::Instruction::BuyExactOut(pb::BuyExactOutInstruction {
+                accounts: Some(pb::TradeAccounts {
+                    payer: acc.payer.to_bytes().to_vec(),
+                    authority: acc.authority.to_bytes().to_vec(),
+                    global_config: acc.global_config.to_bytes().to_vec(),
+                    platform_config: acc.platform_config.to_bytes().to_vec(),
+                    pool_state: acc.pool_state.to_bytes().to_vec(),
+                    user_base_token: acc.user_base_token.to_bytes().to_vec(),
+                    user_quote_token: acc.user_quote_token.to_bytes().to_vec(),
+                    base_vault: acc.base_vault.to_bytes().to_vec(),
+                    quote_vault: acc.quote_vault.to_bytes().to_vec(),
+                    base_token_mint: acc.base_token_mint.to_bytes().to_vec(),
+                    quote_token_mint: acc.quote_token_mint.to_bytes().to_vec(),
+                    base_token_program: acc.base_token_program.to_bytes().to_vec(),
+                    quote_token_program: acc.quote_token_program.to_bytes().to_vec(),
+                    event_authority: acc.event_authority.to_bytes().to_vec(),
+                    program: acc.program.to_bytes().to_vec(),
+                }),
+                amount_out: data.amount_out,
+                maximum_amount_in: data.maximum_amount_in,
+                share_fee_rate: data.share_fee_rate,
+            })
+        }
+        RI::SellExactIn(data) => {
+            let acc = sell_exact_in::SellExactIn::arrange_accounts(&accounts)?;
+            pb::instruction::Instruction::SellExactIn(pb::SellExactInInstruction {
+                accounts: Some(pb::TradeAccounts {
+                    payer: acc.payer.to_bytes().to_vec(),
+                    authority: acc.authority.to_bytes().to_vec(),
+                    global_config: acc.global_config.to_bytes().to_vec(),
+                    platform_config: acc.platform_config.to_bytes().to_vec(),
+                    pool_state: acc.pool_state.to_bytes().to_vec(),
+                    user_base_token: acc.user_base_token.to_bytes().to_vec(),
+                    user_quote_token: acc.user_quote_token.to_bytes().to_vec(),
+                    base_vault: acc.base_vault.to_bytes().to_vec(),
+                    quote_vault: acc.quote_vault.to_bytes().to_vec(),
+                    base_token_mint: acc.base_token_mint.to_bytes().to_vec(),
+                    quote_token_mint: acc.quote_token_mint.to_bytes().to_vec(),
+                    base_token_program: acc.base_token_program.to_bytes().to_vec(),
+                    quote_token_program: acc.quote_token_program.to_bytes().to_vec(),
+                    event_authority: acc.event_authority.to_bytes().to_vec(),
+                    program: acc.program.to_bytes().to_vec(),
+                }),
+                amount_in: data.amount_in,
+                minimum_amount_out: data.minimum_amount_out,
+                share_fee_rate: data.share_fee_rate,
+            })
+        }
+        RI::SellExactOut(data) => {
+            let acc = sell_exact_out::SellExactOut::arrange_accounts(&accounts)?;
+            pb::instruction::Instruction::SellExactOut(pb::SellExactOutInstruction {
+                accounts: Some(pb::TradeAccounts {
+                    payer: acc.payer.to_bytes().to_vec(),
+                    authority: acc.authority.to_bytes().to_vec(),
+                    global_config: acc.global_config.to_bytes().to_vec(),
+                    platform_config: acc.platform_config.to_bytes().to_vec(),
+                    pool_state: acc.pool_state.to_bytes().to_vec(),
+                    user_base_token: acc.user_base_token.to_bytes().to_vec(),
+                    user_quote_token: acc.user_quote_token.to_bytes().to_vec(),
+                    base_vault: acc.base_vault.to_bytes().to_vec(),
+                    quote_vault: acc.quote_vault.to_bytes().to_vec(),
+                    base_token_mint: acc.base_token_mint.to_bytes().to_vec(),
+                    quote_token_mint: acc.quote_token_mint.to_bytes().to_vec(),
+                    base_token_program: acc.base_token_program.to_bytes().to_vec(),
+                    quote_token_program: acc.quote_token_program.to_bytes().to_vec(),
+                    event_authority: acc.event_authority.to_bytes().to_vec(),
+                    program: acc.program.to_bytes().to_vec(),
+                }),
+                amount_out: data.amount_out,
+                maximum_amount_in: data.maximum_amount_in,
+                share_fee_rate: data.share_fee_rate,
+            })
+        }
+        RI::TradeEvent(ev) => {
+            pb::instruction::Instruction::TradeEvent(pb::TradeEvent {
+                pool_state: ev.pool_state.to_bytes().to_vec(),
+                total_base_sell: ev.total_base_sell,
+                virtual_base: ev.virtual_base,
+                virtual_quote: ev.virtual_quote,
+                real_base_before: ev.real_base_before,
+                real_quote_before: ev.real_quote_before,
+                real_base_after: ev.real_base_after,
+                real_quote_after: ev.real_quote_after,
+                amount_in: ev.amount_in,
+                amount_out: ev.amount_out,
+                protocol_fee: ev.protocol_fee,
+                platform_fee: ev.platform_fee,
+                creator_fee: ev.creator_fee,
+                share_fee: ev.share_fee,
+                trade_direction: match ev.trade_direction {
+                    TradeDirection::Buy => pb::TradeDirection::Buy as i32,
+                    TradeDirection::Sell => pb::TradeDirection::Sell as i32,
+                },
+                pool_status: match ev.pool_status {
+                    PoolStatus::Fund => pb::PoolStatus::Fund as i32,
+                    PoolStatus::Migrate => pb::PoolStatus::Migrate as i32,
+                    PoolStatus::Trade => pb::PoolStatus::Trade as i32,
+                },
+                exact_in: ev.exact_in,
+            })
+        }
+        _ => return None,
+    };
+
+    Some(pb::Instruction {
+        program_id: instruction.program_id.to_bytes().to_vec(),
+        stack_height,
+        instruction: Some(instruction),
+    })
+}
+

--- a/raydium-launchpad/substreams.yaml
+++ b/raydium-launchpad/substreams.yaml
@@ -1,0 +1,36 @@
+specVersion: v0.1.0
+package:
+  name: raydium_launchpad
+  version: v0.1.0
+  url: https://github.com/pinax-network/substreams-solana
+  description: Raydium Launchpad events for Solana.
+  image: ../image.png
+
+imports:
+  solana_common: https://github.com/streamingfast/substreams-foundational-modules/releases/download/substreams-v0.3.3/solana-common-v0.3.3.spkg
+
+binaries:
+  default:
+    type: wasm/rust-v1+wasm-bindgen-shims
+    file: ../target/wasm32-unknown-unknown/release/raydium_launchpad.wasm
+
+protobuf:
+  files:
+    - v1/raydium-launchpad.proto
+  importPaths:
+    - ../proto
+
+modules:
+  - name: map_events
+    kind: map
+    inputs:
+      - map: solana_common:blocks_without_votes
+    blockFilter:
+      module: solana_common:program_ids_without_votes
+      query:
+        string: "program:LanMV9sAd7wArD4vJFi2qDdfnVhFxYSUg6eADduJ3uj"
+    output:
+      type: proto:raydium.launchpad.v1.Events
+
+network: solana
+


### PR DESCRIPTION
## Summary
- add proto and generated bindings for Raydium Launchpad
- implement `raydium_launchpad` Substreams module using carbon decoder

## Testing
- `cargo check -p raydium_launchpad` *(fails: failed to select a version for `solana-instruction`)*

------
https://chatgpt.com/codex/tasks/task_b_68b18c5b8db88328afacd0e159f053f5