### PR TITLE
Always REPLACE functions

### DIFF
--- a/clickhouse-solana-dex/schema.0.functions.helpers.sql
+++ b/clickhouse-solana-dex/schema.0.functions.helpers.sql
@@ -1,2 +1,2 @@
-CREATE FUNCTION IF NOT EXISTS to_version AS (block_num, transaction_index, instruction_index) ->
+CREATE OR REPLACE FUNCTION to_version AS (block_num, transaction_index, instruction_index) ->
     block_num * 1e6 + transaction_index * 1e3 + instruction_index;

--- a/clickhouse-solana-dex/schema.0.functions.programs.sql
+++ b/clickhouse-solana-dex/schema.0.functions.programs.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION IF NOT EXISTS program_names AS ( program_id ) -> CASE program_id
+CREATE OR REPLACE FUNCTION program_names AS ( program_id ) -> CASE program_id
     WHEN CAST ('675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8' AS FixedString(44)) THEN 'Raydium Liquidity Pool V4'
     WHEN CAST ('6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P' AS FixedString(44)) THEN 'Pump.fun'
     WHEN CAST ('pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA' AS FixedString(44)) THEN 'Pump.fun AMM'

--- a/clickhouse-solana-dex/schema.0.functions.tokens.sql
+++ b/clickhouse-solana-dex/schema.0.functions.tokens.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION IF NOT EXISTS token_types AS ( program_id ) -> CASE program_id
+CREATE OR REPLACE FUNCTION token_types AS ( program_id ) -> CASE program_id
     WHEN CAST ('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB' AS FixedString(44)) THEN 'USD'
     WHEN CAST ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' AS FixedString(44)) THEN 'USD'
     WHEN CAST ('2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk' AS FixedString(44)) THEN 'ETH'
@@ -11,7 +11,7 @@ CREATE FUNCTION IF NOT EXISTS token_types AS ( program_id ) -> CASE program_id
     ELSE 'Unknown'
 END;
 
-CREATE FUNCTION IF NOT EXISTS token_names AS ( program_id ) -> CASE program_id
+CREATE OR REPLACE FUNCTION token_names AS ( program_id ) -> CASE program_id
     WHEN CAST ('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB' AS FixedString(44)) THEN 'Tether USD'
     WHEN CAST ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' AS FixedString(44)) THEN 'Circle: USDC Token'
     WHEN CAST ('2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk' AS FixedString(44)) THEN 'Wrapped ETH "Sollet"'

--- a/clickhouse-solana-tokens/schema.0.functions.helpers.sql
+++ b/clickhouse-solana-tokens/schema.0.functions.helpers.sql
@@ -1,7 +1,7 @@
 -- Split a comma-separated string into Array(String)
 -- - Trims whitespace around tokens
 -- - Drops empty tokens
-CREATE FUNCTION IF NOT EXISTS string_to_array AS (raw) ->
+CREATE OR REPLACE FUNCTION string_to_array AS (raw) ->
     arrayFilter(x -> x != '',
         arrayMap(x -> trim(x),
             splitByChar(',', ifNull(raw, ''))
@@ -10,13 +10,13 @@ CREATE FUNCTION IF NOT EXISTS string_to_array AS (raw) ->
 
 -- String to UInt8 conversion
 -- Returns NULL if the input is empty or NULL
-CREATE FUNCTION IF NOT EXISTS string_to_uint8 AS (raw) ->
+CREATE OR REPLACE FUNCTION string_to_uint8 AS (raw) ->
     toUInt8OrNull(nullIf(raw, ''));
 
 -- Accurate cast or NULL
 -- Returns NULL if the input is empty or NULL
-CREATE FUNCTION IF NOT EXISTS string_or_null AS (raw) ->
+CREATE OR REPLACE FUNCTION string_or_null AS (raw) ->
     accurateCastOrNull(nullIf(trimBoth(raw), ''), 'String');
 
-CREATE FUNCTION IF NOT EXISTS to_version AS (block_num, transaction_index, instruction_index) ->
+CREATE OR REPLACE FUNCTION to_version AS (block_num, transaction_index, instruction_index) ->
     block_num * 1e6 + transaction_index * 1e3 + instruction_index;

--- a/clickhouse-solana-tokens/schema.0.functions.tokens.sql
+++ b/clickhouse-solana-tokens/schema.0.functions.tokens.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION IF NOT EXISTS token_types AS ( program_id ) -> CASE program_id
+CREATE OR REPLACE FUNCTION token_types AS ( program_id ) -> CASE program_id
     WHEN 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB' THEN 'USD'
     WHEN 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' THEN 'USD'
     WHEN '2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk' THEN 'ETH'
@@ -11,7 +11,7 @@ CREATE FUNCTION IF NOT EXISTS token_types AS ( program_id ) -> CASE program_id
     ELSE 'Unknown'
 END;
 
-CREATE FUNCTION IF NOT EXISTS token_names AS ( program_id ) -> CASE program_id
+CREATE OR REPLACE FUNCTION token_names AS ( program_id ) -> CASE program_id
     WHEN 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB' THEN 'Tether USD'
     WHEN 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' THEN 'Circle: USDC Token'
     WHEN '2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk' THEN 'Wrapped ETH "Sollet"'


### PR DESCRIPTION
Functions are global in Clickhouse so we have to always replace them, otherwise if we use "IF NOT EXISTS" we'll be stuck with the first ever version.
This PR forces "CREATE OR REPLACE".