### PR TITLE
Add Meteora AMM substream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "meteora_amm"
+version = "0.0.0"
+dependencies = [
+ "common",
+ "proto",
+ "substreams",
+ "substreams-solana",
+ "substreams-solana-idls",
+]
+
+[[package]]
 name = "mpl-token-metadata"
 version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "raydium-launchpad",
   "metaplex",
   "bonk-swap",
+  "meteora/amm",
 
   # # General
   # "clickhouse-transactions",

--- a/meteora/amm/Cargo.toml
+++ b/meteora/amm/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "meteora_amm"
+description = "Meteora AMM"
+edition = { workspace = true }
+version = { workspace = true }
+authors = ["Denis <denis@pinax.network>"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+substreams = { workspace = true }
+substreams-solana = { workspace = true }
+substreams-solana-idls = { workspace = true }
+proto = { path = "../../proto" }
+common = { path = "../../common" }

--- a/meteora/amm/Makefile
+++ b/meteora/amm/Makefile
@@ -1,0 +1,23 @@
+ENDPOINT ?= solana.substreams.pinax.network:443
+START_BLOCK ?= 0
+PARALLEL_JOBS ?= 500
+
+.PHONY: build
+build:
+cargo build --target wasm32-unknown-unknown --release
+
+.PHONY: pack
+pack: build
+substreams pack
+
+.PHONY: noop
+noop: build
+substreams-sink-noop $(ENDPOINT) substreams.yaml map_events -H "X-Sf-Substreams-Parallel-Jobs: $(PARALLEL_JOBS)" $(START_BLOCK):
+
+.PHONY: gui
+gui: build
+substreams gui -e $(ENDPOINT) substreams.yaml map_events -s $(START_BLOCK) --network solana
+
+.PHONY: prod
+prod: build
+substreams gui -e $(ENDPOINT) substreams.yaml map_events -s $(START_BLOCK) -t 0 --limit-processed-blocks 0 --production-mode  -H "X-Sf-Substreams-Parallel-Jobs: $(PARALLEL_JOBS)"

--- a/meteora/amm/src/lib.rs
+++ b/meteora/amm/src/lib.rs
@@ -1,0 +1,279 @@
+use common::solana::{get_fee_payer, get_signers, is_invoke, parse_invoke_depth, parse_program_data, parse_program_id};
+use proto::pb::meteora::amm::v1 as pb;
+use substreams::errors::Error;
+use substreams_solana::{
+    block_view::InstructionView,
+    pb::sf::solana::r#type::v1::{Block, ConfirmedTransaction, TransactionStatusMeta},
+};
+use substreams_solana_idls::meteora;
+
+#[substreams::handlers::map]
+fn map_events(block: Block) -> Result<pb::Events, Error> {
+    Ok(pb::Events {
+        transactions: block.transactions_owned().filter_map(process_transaction).collect(),
+    })
+}
+
+fn process_transaction(tx: ConfirmedTransaction) -> Option<pb::Transaction> {
+    let tx_meta = tx.meta.as_ref()?;
+
+    let instructions: Vec<pb::Instruction> = tx.walk_instructions().filter_map(|iv| process_instruction(&iv)).collect();
+    let logs = process_logs(tx_meta, &meteora::amm::PROGRAM_ID.to_vec());
+
+    if instructions.is_empty() && logs.is_empty() {
+        return None;
+    }
+
+    Some(pb::Transaction {
+        fee: tx_meta.fee,
+        compute_units_consumed: tx_meta.compute_units_consumed(),
+        signature: tx.hash().to_vec(),
+        fee_payer: get_fee_payer(&tx).unwrap_or_default(),
+        signers: get_signers(&tx).unwrap_or_default(),
+        instructions,
+        logs,
+    })
+}
+
+fn process_instruction(ix: &InstructionView) -> Option<pb::Instruction> {
+    let program_id = ix.program_id().0;
+    if program_id != &meteora::amm::PROGRAM_ID {
+        return None;
+    }
+
+    match meteora::amm::instructions::unpack(ix.data()) {
+        Ok(meteora::amm::instructions::AmmInstruction::Swap(evt)) => {
+            let accounts = meteora::amm::accounts::get_swap_accounts(ix).ok()?;
+            Some(pb::Instruction {
+                program_id: program_id.to_vec(),
+                stack_height: ix.stack_height(),
+                instruction: Some(pb::instruction::Instruction::Swap(pb::SwapInstruction {
+                    accounts: Some(pb::SwapAccounts {
+                        pool: accounts.pool.to_bytes().to_vec(),
+                        user_source_token: accounts.user_source_token.to_bytes().to_vec(),
+                        user_destination_token: accounts.user_destination_token.to_bytes().to_vec(),
+                        a_vault: accounts.a_vault.to_bytes().to_vec(),
+                        b_vault: accounts.b_vault.to_bytes().to_vec(),
+                        a_token_vault: accounts.a_token_vault.to_bytes().to_vec(),
+                        b_token_vault: accounts.b_token_vault.to_bytes().to_vec(),
+                        a_vault_lp_mint: accounts.a_vault_lp_mint.to_bytes().to_vec(),
+                        b_vault_lp_mint: accounts.b_vault_lp_mint.to_bytes().to_vec(),
+                        a_vault_lp: accounts.a_vault_lp.to_bytes().to_vec(),
+                        b_vault_lp: accounts.b_vault_lp.to_bytes().to_vec(),
+                        protocol_token_fee: accounts.protocol_token_fee.to_bytes().to_vec(),
+                        user: accounts.user.to_bytes().to_vec(),
+                        vault_program: accounts.vault_program.to_bytes().to_vec(),
+                        token_program: accounts.token_program.to_bytes().to_vec(),
+                    }),
+                    in_amount: evt.in_amount,
+                    minimum_out_amount: evt.minimum_out_amount,
+                })),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn process_logs(tx_meta: &TransactionStatusMeta, program_id_bytes: &[u8]) -> Vec<pb::Log> {
+    let mut logs = Vec::new();
+    let mut is_invoked = false;
+
+    for log_message in tx_meta.log_messages.iter() {
+        let match_program_id = parse_program_id(log_message).map_or(false, |id| id == program_id_bytes.to_vec());
+
+        if is_invoke(log_message) && match_program_id {
+            if let Some(invoke_depth) = parse_invoke_depth(log_message) {
+                is_invoked = true;
+                if let Some(log_data) = parse_log_data(log_message, program_id_bytes, invoke_depth) {
+                    logs.push(log_data);
+                }
+            }
+        } else if is_invoked {
+            if let Some(log_data) = parse_log_data(log_message, program_id_bytes, 0) {
+                logs.push(log_data);
+            }
+        }
+    }
+
+    logs
+}
+
+fn parse_log_data(log_message: &str, program_id_bytes: &[u8], invoke_depth: u32) -> Option<pb::Log> {
+    let data = parse_program_data(log_message)?;
+    match meteora::amm::events::parse_event(data.as_slice()) {
+        Ok(meteora::amm::events::AmmEvent::AddLiquidity(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::AddLiquidity(pb::AddLiquidityLog {
+                lp_mint_amount: evt.lp_mint_amount,
+                token_a_amount: evt.token_a_amount,
+                token_b_amount: evt.token_b_amount,
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::RemoveLiquidity(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::RemoveLiquidity(pb::RemoveLiquidityLog {
+                lp_unmint_amount: evt.lp_unmint_amount,
+                token_a_out_amount: evt.token_a_out_amount,
+                token_b_out_amount: evt.token_b_out_amount,
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::BootstrapLiquidity(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::BootstrapLiquidity(pb::BootstrapLiquidityLog {
+                lp_mint_amount: evt.lp_mint_amount,
+                token_a_amount: evt.token_a_amount,
+                token_b_amount: evt.token_b_amount,
+                pool: evt.pool.to_bytes().to_vec(),
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::Swap(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::Swap(pb::SwapLog {
+                in_amount: evt.in_amount,
+                out_amount: evt.out_amount,
+                trade_fee: evt.trade_fee,
+                protocol_fee: evt.protocol_fee,
+                host_fee: evt.host_fee,
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::SetPoolFees(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::SetPoolFees(pb::SetPoolFeesLog {
+                trade_fee_numerator: evt.trade_fee_numerator,
+                trade_fee_denominator: evt.trade_fee_denominator,
+                protocol_trade_fee_numerator: evt.protocol_trade_fee_numerator,
+                protocol_trade_fee_denominator: evt.protocol_trade_fee_denominator,
+                pool: evt.pool.to_bytes().to_vec(),
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::PoolInfo(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::PoolInfo(pb::PoolInfoLog {
+                token_a_amount: evt.token_a_amount,
+                token_b_amount: evt.token_b_amount,
+                virtual_price: evt.virtual_price,
+                current_timestamp: evt.current_timestamp,
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::TransferAdmin(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::TransferAdmin(pb::TransferAdminLog {
+                admin: evt.admin.to_bytes().to_vec(),
+                new_admin: evt.new_admin.to_bytes().to_vec(),
+                pool: evt.pool.to_bytes().to_vec(),
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::OverrideCurveParam(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::OverrideCurveParam(pb::OverrideCurveParamLog {
+                new_amp: evt.new_amp,
+                updated_timestamp: evt.updated_timestamp,
+                pool: evt.pool.to_bytes().to_vec(),
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::PoolCreated(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::PoolCreated(pb::PoolCreatedLog {
+                lp_mint: evt.lp_mint.to_bytes().to_vec(),
+                token_a_mint: evt.token_a_mint.to_bytes().to_vec(),
+                token_b_mint: evt.token_b_mint.to_bytes().to_vec(),
+                pool_type: evt.pool_type as u32,
+                pool: evt.pool.to_bytes().to_vec(),
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::PoolEnabled(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::PoolEnabled(pb::PoolEnabledLog {
+                pool: evt.pool.to_bytes().to_vec(),
+                enabled: evt.enabled,
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::MigrateFeeAccount(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::MigrateFeeAccount(pb::MigrateFeeAccountLog {
+                pool: evt.pool.to_bytes().to_vec(),
+                new_admin_token_a_fee: evt.new_admin_token_a_fee.to_bytes().to_vec(),
+                new_admin_token_b_fee: evt.new_admin_token_b_fee.to_bytes().to_vec(),
+                token_a_amount: evt.token_a_amount,
+                token_b_amount: evt.token_b_amount,
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::CreateLockEscrow(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::CreateLockEscrow(pb::CreateLockEscrowLog {
+                pool: evt.pool.to_bytes().to_vec(),
+                owner: evt.owner.to_bytes().to_vec(),
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::Lock(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::Lock(pb::LockLog {
+                pool: evt.pool.to_bytes().to_vec(),
+                owner: evt.owner.to_bytes().to_vec(),
+                amount: evt.amount,
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::ClaimFee(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::ClaimFee(pb::ClaimFeeLog {
+                pool: evt.pool.to_bytes().to_vec(),
+                owner: evt.owner.to_bytes().to_vec(),
+                amount: evt.amount,
+                a_fee: evt.a_fee,
+                b_fee: evt.b_fee,
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::CreateConfig(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::CreateConfig(pb::CreateConfigLog {
+                trade_fee_numerator: evt.trade_fee_numerator,
+                protocol_trade_fee_numerator: evt.protocol_trade_fee_numerator,
+                config: evt.config.to_bytes().to_vec(),
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::CloseConfig(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::CloseConfig(pb::CloseConfigLog {
+                config: evt.config.to_bytes().to_vec(),
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::WithdrawProtocolFees(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::WithdrawProtocolFees(pb::WithdrawProtocolFeesLog {
+                pool: evt.pool.to_bytes().to_vec(),
+                protocol_a_fee: evt.protocol_a_fee,
+                protocol_b_fee: evt.protocol_b_fee,
+                protocol_a_fee_owner: evt.protocol_a_fee_owner.to_bytes().to_vec(),
+                protocol_b_fee_owner: evt.protocol_b_fee_owner.to_bytes().to_vec(),
+            })),
+        }),
+        Ok(meteora::amm::events::AmmEvent::PartnerClaimFees(evt)) => Some(pb::Log {
+            program_id: program_id_bytes.to_vec(),
+            invoke_depth,
+            log: Some(pb::log::Log::PartnerClaimFees(pb::PartnerClaimFeesLog {
+                pool: evt.pool.to_bytes().to_vec(),
+                fee_a: evt.fee_a,
+                fee_b: evt.fee_b,
+                partner: evt.partner.to_bytes().to_vec(),
+            })),
+        }),
+        _ => None,
+    }
+}

--- a/meteora/amm/substreams.yaml
+++ b/meteora/amm/substreams.yaml
@@ -1,0 +1,35 @@
+specVersion: v0.1.0
+package:
+  name: meteora_amm
+  version: v0.1.0
+  url: https://github.com/pinax-network/substreams-solana
+  description: Meteora AMM events for Solana.
+  image: ../../image.png
+
+imports:
+  solana_common: https://github.com/streamingfast/substreams-foundational-modules/releases/download/substreams-v0.3.3/solana-common-v0.3.3.spkg
+
+binaries:
+  default:
+    type: wasm/rust-v1+wasm-bindgen-shims
+    file: ../../target/wasm32-unknown-unknown/release/meteora_amm.wasm
+
+protobuf:
+  files:
+    - v1/meteora-amm.proto
+  importPaths:
+    - ../../proto
+
+modules:
+  - name: map_events
+    kind: map
+    inputs:
+      - map: solana_common:blocks_without_votes
+    blockFilter:
+      module: solana_common:program_ids_without_votes
+      query:
+        string: "program:Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB"
+    output:
+      type: proto:meteora.amm.v1.Events
+
+network: solana

--- a/proto/src/pb/meteora.amm.v1.rs
+++ b/proto/src/pb/meteora.amm.v1.rs
@@ -1,0 +1,353 @@
+// @generated
+// This file was generated manually as protogen execution was unavailable.
+// -----------------------------------------------------------------------------
+// Top-level containers
+// -----------------------------------------------------------------------------
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Events {
+    #[prost(message, repeated, tag="1")]
+    pub transactions: ::prost::alloc::vec::Vec<Transaction>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Transaction {
+    #[prost(bytes = "vec", tag = "1")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub fee_payer: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", repeated, tag = "3")]
+    pub signers: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(uint64, tag = "4")]
+    pub fee: u64,
+    #[prost(uint64, tag = "5")]
+    pub compute_units_consumed: u64,
+    #[prost(message, repeated, tag = "6")]
+    pub instructions: ::prost::alloc::vec::Vec<Instruction>,
+    #[prost(message, repeated, tag = "7")]
+    pub logs: ::prost::alloc::vec::Vec<Log>,
+}
+// -----------------------------------------------------------------------------
+// Instructions
+// -----------------------------------------------------------------------------
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Instruction {
+    #[prost(bytes = "vec", tag = "1")]
+    pub program_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint32, tag = "2")]
+    pub stack_height: u32,
+    #[prost(oneof = "instruction::Instruction", tags = "3")]
+    pub instruction: ::core::option::Option<instruction::Instruction>,
+}
+/// Nested message and enum types in `Instruction`.
+pub mod instruction {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Instruction {
+        #[prost(message, tag = "3")]
+        Swap(super::SwapInstruction),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SwapInstruction {
+    #[prost(message, optional, tag = "1")]
+    pub accounts: ::core::option::Option<SwapAccounts>,
+    #[prost(uint64, tag = "2")]
+    pub in_amount: u64,
+    #[prost(uint64, tag = "3")]
+    pub minimum_out_amount: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SwapAccounts {
+    #[prost(bytes = "vec", tag = "1")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub user_source_token: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub user_destination_token: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub a_vault: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "5")]
+    pub b_vault: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "6")]
+    pub a_token_vault: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "7")]
+    pub b_token_vault: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "8")]
+    pub a_vault_lp_mint: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "9")]
+    pub b_vault_lp_mint: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "10")]
+    pub a_vault_lp: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "11")]
+    pub b_vault_lp: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "12")]
+    pub protocol_token_fee: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "13")]
+    pub user: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "14")]
+    pub vault_program: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "15")]
+    pub token_program: ::prost::alloc::vec::Vec<u8>,
+}
+// -----------------------------------------------------------------------------
+// Logs
+// -----------------------------------------------------------------------------
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Log {
+    #[prost(bytes = "vec", tag = "1")]
+    pub program_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint32, tag = "2")]
+    pub invoke_depth: u32,
+    #[prost(oneof = "log::Log", tags = "3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20")]
+    pub log: ::core::option::Option<log::Log>,
+}
+/// Nested message and enum types in `Log`.
+pub mod log {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Log {
+        #[prost(message, tag = "3")]
+        AddLiquidity(super::AddLiquidityLog),
+        #[prost(message, tag = "4")]
+        RemoveLiquidity(super::RemoveLiquidityLog),
+        #[prost(message, tag = "5")]
+        BootstrapLiquidity(super::BootstrapLiquidityLog),
+        #[prost(message, tag = "6")]
+        Swap(super::SwapLog),
+        #[prost(message, tag = "7")]
+        SetPoolFees(super::SetPoolFeesLog),
+        #[prost(message, tag = "8")]
+        PoolInfo(super::PoolInfoLog),
+        #[prost(message, tag = "9")]
+        TransferAdmin(super::TransferAdminLog),
+        #[prost(message, tag = "10")]
+        OverrideCurveParam(super::OverrideCurveParamLog),
+        #[prost(message, tag = "11")]
+        PoolCreated(super::PoolCreatedLog),
+        #[prost(message, tag = "12")]
+        PoolEnabled(super::PoolEnabledLog),
+        #[prost(message, tag = "13")]
+        MigrateFeeAccount(super::MigrateFeeAccountLog),
+        #[prost(message, tag = "14")]
+        CreateLockEscrow(super::CreateLockEscrowLog),
+        #[prost(message, tag = "15")]
+        Lock(super::LockLog),
+        #[prost(message, tag = "16")]
+        ClaimFee(super::ClaimFeeLog),
+        #[prost(message, tag = "17")]
+        CreateConfig(super::CreateConfigLog),
+        #[prost(message, tag = "18")]
+        CloseConfig(super::CloseConfigLog),
+        #[prost(message, tag = "19")]
+        WithdrawProtocolFees(super::WithdrawProtocolFeesLog),
+        #[prost(message, tag = "20")]
+        PartnerClaimFees(super::PartnerClaimFeesLog),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AddLiquidityLog {
+    #[prost(uint64, tag = "1")]
+    pub lp_mint_amount: u64,
+    #[prost(uint64, tag = "2")]
+    pub token_a_amount: u64,
+    #[prost(uint64, tag = "3")]
+    pub token_b_amount: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RemoveLiquidityLog {
+    #[prost(uint64, tag = "1")]
+    pub lp_unmint_amount: u64,
+    #[prost(uint64, tag = "2")]
+    pub token_a_out_amount: u64,
+    #[prost(uint64, tag = "3")]
+    pub token_b_out_amount: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BootstrapLiquidityLog {
+    #[prost(uint64, tag = "1")]
+    pub lp_mint_amount: u64,
+    #[prost(uint64, tag = "2")]
+    pub token_a_amount: u64,
+    #[prost(uint64, tag = "3")]
+    pub token_b_amount: u64,
+    #[prost(bytes = "vec", tag = "4")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SwapLog {
+    #[prost(uint64, tag = "1")]
+    pub in_amount: u64,
+    #[prost(uint64, tag = "2")]
+    pub out_amount: u64,
+    #[prost(uint64, tag = "3")]
+    pub trade_fee: u64,
+    #[prost(uint64, tag = "4")]
+    pub protocol_fee: u64,
+    #[prost(uint64, tag = "5")]
+    pub host_fee: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetPoolFeesLog {
+    #[prost(uint64, tag = "1")]
+    pub trade_fee_numerator: u64,
+    #[prost(uint64, tag = "2")]
+    pub trade_fee_denominator: u64,
+    #[prost(uint64, tag = "3")]
+    pub protocol_trade_fee_numerator: u64,
+    #[prost(uint64, tag = "4")]
+    pub protocol_trade_fee_denominator: u64,
+    #[prost(bytes = "vec", tag = "5")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PoolInfoLog {
+    #[prost(uint64, tag = "1")]
+    pub token_a_amount: u64,
+    #[prost(uint64, tag = "2")]
+    pub token_b_amount: u64,
+    #[prost(double, tag = "3")]
+    pub virtual_price: f64,
+    #[prost(uint64, tag = "4")]
+    pub current_timestamp: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransferAdminLog {
+    #[prost(bytes = "vec", tag = "1")]
+    pub admin: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub new_admin: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OverrideCurveParamLog {
+    #[prost(uint64, tag = "1")]
+    pub new_amp: u64,
+    #[prost(uint64, tag = "2")]
+    pub updated_timestamp: u64,
+    #[prost(bytes = "vec", tag = "3")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PoolCreatedLog {
+    #[prost(bytes = "vec", tag = "1")]
+    pub lp_mint: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub token_a_mint: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub token_b_mint: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint32, tag = "4")]
+    pub pool_type: u32,
+    #[prost(bytes = "vec", tag = "5")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PoolEnabledLog {
+    #[prost(bytes = "vec", tag = "1")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bool, tag = "2")]
+    pub enabled: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MigrateFeeAccountLog {
+    #[prost(bytes = "vec", tag = "1")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub new_admin_token_a_fee: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub new_admin_token_b_fee: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "4")]
+    pub token_a_amount: u64,
+    #[prost(uint64, tag = "5")]
+    pub token_b_amount: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateLockEscrowLog {
+    #[prost(bytes = "vec", tag = "1")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub owner: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LockLog {
+    #[prost(bytes = "vec", tag = "1")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub owner: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "3")]
+    pub amount: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ClaimFeeLog {
+    #[prost(bytes = "vec", tag = "1")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub owner: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "3")]
+    pub amount: u64,
+    #[prost(uint64, tag = "4")]
+    pub a_fee: u64,
+    #[prost(uint64, tag = "5")]
+    pub b_fee: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateConfigLog {
+    #[prost(uint64, tag = "1")]
+    pub trade_fee_numerator: u64,
+    #[prost(uint64, tag = "2")]
+    pub protocol_trade_fee_numerator: u64,
+    #[prost(bytes = "vec", tag = "3")]
+    pub config: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CloseConfigLog {
+    #[prost(bytes = "vec", tag = "1")]
+    pub config: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WithdrawProtocolFeesLog {
+    #[prost(bytes = "vec", tag = "1")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "2")]
+    pub protocol_a_fee: u64,
+    #[prost(uint64, tag = "3")]
+    pub protocol_b_fee: u64,
+    #[prost(bytes = "vec", tag = "4")]
+    pub protocol_a_fee_owner: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "5")]
+    pub protocol_b_fee_owner: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PartnerClaimFeesLog {
+    #[prost(bytes = "vec", tag = "1")]
+    pub pool: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "2")]
+    pub fee_a: u64,
+    #[prost(uint64, tag = "3")]
+    pub fee_b: u64,
+    #[prost(bytes = "vec", tag = "4")]
+    pub partner: ::prost::alloc::vec::Vec<u8>,
+}

--- a/proto/src/pb/mod.rs
+++ b/proto/src/pb/mod.rs
@@ -15,6 +15,15 @@ pub mod jupiter {
         // @@protoc_insertion_point(jupiter.v1)
     }
 }
+pub mod meteora {
+    pub mod amm {
+        // @@protoc_insertion_point(attribute:meteora.amm.v1)
+        pub mod v1 {
+            include!("meteora.amm.v1.rs");
+            // @@protoc_insertion_point(meteora.amm.v1)
+        }
+    }
+}
 pub mod pumpfun {
     pub mod amm {
         // @@protoc_insertion_point(attribute:pumpfun.amm.v1)

--- a/proto/substreams.yaml
+++ b/proto/substreams.yaml
@@ -16,6 +16,7 @@ protobuf:
     - v1/raydium-cpmm.proto
     - v1/metaplex.proto
     - v1/raydium-launchpad.proto
+    - v1/meteora-amm.proto
   excludePaths:
     - sf/substreams
     - sf/solana

--- a/proto/v1/meteora-amm.proto
+++ b/proto/v1/meteora-amm.proto
@@ -1,0 +1,202 @@
+syntax = "proto3";
+
+package meteora.amm.v1;
+
+// -----------------------------------------------------------------------------
+// Top-level containers
+// -----------------------------------------------------------------------------
+message Events {
+  repeated Transaction transactions = 1;
+}
+
+message Transaction {
+  bytes signature = 1;
+  bytes fee_payer = 2;
+  repeated bytes signers = 3;
+  uint64 fee = 4;
+  uint64 compute_units_consumed = 5;
+  repeated Instruction instructions = 6;
+  repeated Log logs = 7;
+}
+
+// -----------------------------------------------------------------------------
+// Instructions
+// -----------------------------------------------------------------------------
+message Instruction {
+  bytes program_id = 1;
+  uint32 stack_height = 2;
+  oneof instruction {
+    SwapInstruction swap = 3;
+  }
+}
+
+message SwapInstruction {
+  SwapAccounts accounts = 1;
+  uint64 in_amount = 2;
+  uint64 minimum_out_amount = 3;
+}
+
+message SwapAccounts {
+  bytes pool = 1;
+  bytes user_source_token = 2;
+  bytes user_destination_token = 3;
+  bytes a_vault = 4;
+  bytes b_vault = 5;
+  bytes a_token_vault = 6;
+  bytes b_token_vault = 7;
+  bytes a_vault_lp_mint = 8;
+  bytes b_vault_lp_mint = 9;
+  bytes a_vault_lp = 10;
+  bytes b_vault_lp = 11;
+  bytes protocol_token_fee = 12;
+  bytes user = 13;
+  bytes vault_program = 14;
+  bytes token_program = 15;
+}
+
+// -----------------------------------------------------------------------------
+// Logs
+// -----------------------------------------------------------------------------
+message Log {
+  bytes program_id = 1;
+  uint32 invoke_depth = 2;
+  oneof log {
+    AddLiquidityLog add_liquidity = 3;
+    RemoveLiquidityLog remove_liquidity = 4;
+    BootstrapLiquidityLog bootstrap_liquidity = 5;
+    SwapLog swap = 6;
+    SetPoolFeesLog set_pool_fees = 7;
+    PoolInfoLog pool_info = 8;
+    TransferAdminLog transfer_admin = 9;
+    OverrideCurveParamLog override_curve_param = 10;
+    PoolCreatedLog pool_created = 11;
+    PoolEnabledLog pool_enabled = 12;
+    MigrateFeeAccountLog migrate_fee_account = 13;
+    CreateLockEscrowLog create_lock_escrow = 14;
+    LockLog lock = 15;
+    ClaimFeeLog claim_fee = 16;
+    CreateConfigLog create_config = 17;
+    CloseConfigLog close_config = 18;
+    WithdrawProtocolFeesLog withdraw_protocol_fees = 19;
+    PartnerClaimFeesLog partner_claim_fees = 20;
+  }
+}
+
+message AddLiquidityLog {
+  uint64 lp_mint_amount = 1;
+  uint64 token_a_amount = 2;
+  uint64 token_b_amount = 3;
+}
+
+message RemoveLiquidityLog {
+  uint64 lp_unmint_amount = 1;
+  uint64 token_a_out_amount = 2;
+  uint64 token_b_out_amount = 3;
+}
+
+message BootstrapLiquidityLog {
+  uint64 lp_mint_amount = 1;
+  uint64 token_a_amount = 2;
+  uint64 token_b_amount = 3;
+  bytes pool = 4;
+}
+
+message SwapLog {
+  uint64 in_amount = 1;
+  uint64 out_amount = 2;
+  uint64 trade_fee = 3;
+  uint64 protocol_fee = 4;
+  uint64 host_fee = 5;
+}
+
+message SetPoolFeesLog {
+  uint64 trade_fee_numerator = 1;
+  uint64 trade_fee_denominator = 2;
+  uint64 protocol_trade_fee_numerator = 3;
+  uint64 protocol_trade_fee_denominator = 4;
+  bytes pool = 5;
+}
+
+message PoolInfoLog {
+  uint64 token_a_amount = 1;
+  uint64 token_b_amount = 2;
+  double virtual_price = 3;
+  uint64 current_timestamp = 4;
+}
+
+message TransferAdminLog {
+  bytes admin = 1;
+  bytes new_admin = 2;
+  bytes pool = 3;
+}
+
+message OverrideCurveParamLog {
+  uint64 new_amp = 1;
+  uint64 updated_timestamp = 2;
+  bytes pool = 3;
+}
+
+message PoolCreatedLog {
+  bytes lp_mint = 1;
+  bytes token_a_mint = 2;
+  bytes token_b_mint = 3;
+  uint32 pool_type = 4;
+  bytes pool = 5;
+}
+
+message PoolEnabledLog {
+  bytes pool = 1;
+  bool enabled = 2;
+}
+
+message MigrateFeeAccountLog {
+  bytes pool = 1;
+  bytes new_admin_token_a_fee = 2;
+  bytes new_admin_token_b_fee = 3;
+  uint64 token_a_amount = 4;
+  uint64 token_b_amount = 5;
+}
+
+message CreateLockEscrowLog {
+  bytes pool = 1;
+  bytes owner = 2;
+}
+
+message LockLog {
+  bytes pool = 1;
+  bytes owner = 2;
+  uint64 amount = 3;
+}
+
+message ClaimFeeLog {
+  bytes pool = 1;
+  bytes owner = 2;
+  uint64 amount = 3;
+  uint64 a_fee = 4;
+  uint64 b_fee = 5;
+}
+
+message CreateConfigLog {
+  uint64 trade_fee_numerator = 1;
+  uint64 protocol_trade_fee_numerator = 2;
+  bytes config = 3;
+}
+
+message CloseConfigLog {
+  bytes config = 1;
+}
+
+message WithdrawProtocolFeesLog {
+  bytes pool = 1;
+  uint64 protocol_a_fee = 2;
+  uint64 protocol_b_fee = 3;
+  bytes protocol_a_fee_owner = 4;
+  bytes protocol_b_fee_owner = 5;
+}
+
+message PartnerClaimFeesLog {
+  bytes pool = 1;
+  uint64 fee_a = 2;
+  uint64 fee_b = 3;
+  bytes partner = 4;
+}


### PR DESCRIPTION
## Summary
- add Meteora AMM protobuf definitions and generated bindings
- implement Meteora AMM map module parsing swap instruction and rich event logs
- wire Meteora AMM package into workspace and Substreams config

## Testing
- `cargo check -p meteora_amm`
- `cd proto && make protogen` *(fails: server hosted at that remote is unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_68c184402250832887e0048c2966414c