### PR TITLE
Reset DLMM log parser invocation flag

### DIFF
--- a/meteora_dllm/src/lib.rs
+++ b/meteora_dllm/src/lib.rs
@@ -1,4 +1,4 @@
-use common::solana::{get_fee_payer, get_signers, is_invoke, parse_invoke_depth, parse_program_data, parse_program_id};
+use common::solana::{get_fee_payer, get_signers, is_invoke, is_success, parse_invoke_depth, parse_program_data, parse_program_id};
 use proto::pb::meteora::dllm::v1 as pb;
 use substreams::errors::Error;
 use substreams_solana::{
@@ -89,6 +89,10 @@ fn process_logs(tx_meta: &TransactionStatusMeta, program_id_bytes: &[u8]) -> Vec
                 }
             }
         } else if is_invoked {
+            if match_program_id && (is_success(log_message) || log_message.contains(" failed")) {
+                is_invoked = false;
+                continue;
+            }
             if let Some(log_data) = parse_log_data(log_message, program_id_bytes, 0) {
                 logs.push(log_data);
             }

--- a/proto/src/pb/mod.rs
+++ b/proto/src/pb/mod.rs
@@ -15,15 +15,6 @@ pub mod jupiter {
         // @@protoc_insertion_point(jupiter.v1)
     }
 }
-pub mod meteora {
-    pub mod amm {
-        // @@protoc_insertion_point(attribute:meteora.amm.v1)
-        pub mod v1 {
-            include!("meteora.amm.v1.rs");
-            // @@protoc_insertion_point(meteora.amm.v1)
-        }
-    }
-}
 pub mod pumpfun {
     pub mod amm {
         // @@protoc_insertion_point(attribute:pumpfun.amm.v1)
@@ -68,15 +59,6 @@ pub mod raydium {
         }
     }
 }
-pub mod meteora {
-    pub mod dllm {
-        // @@protoc_insertion_point(attribute:meteora.dllm.v1)
-        pub mod v1 {
-            include!("meteora.dllm.v1.rs");
-            // @@protoc_insertion_point(meteora.dllm.v1)
-        }
-    }
-}
 pub mod solana {
     pub mod metaplex {
         // @@protoc_insertion_point(attribute:solana.metaplex.v1)
@@ -106,6 +88,20 @@ pub mod solana {
 }
 
 pub mod meteora {
+    pub mod amm {
+        // @@protoc_insertion_point(attribute:meteora.amm.v1)
+        pub mod v1 {
+            include!("meteora.amm.v1.rs");
+            // @@protoc_insertion_point(meteora.amm.v1)
+        }
+    }
+    pub mod dllm {
+        // @@protoc_insertion_point(attribute:meteora.dllm.v1)
+        pub mod v1 {
+            include!("meteora.dllm.v1.rs");
+            // @@protoc_insertion_point(meteora.dllm.v1)
+        }
+    }
     pub mod daam {
         // @@protoc_insertion_point(attribute:meteora.daam.v1)
         pub mod v1 {


### PR DESCRIPTION
## Summary
- reset invocation flag after program success or failure
- consolidate Meteora protobuf modules to avoid duplicates

## Testing
- `cargo build -p meteora_dllm` *(fails: process hung while compiling `substreams-solana-idls`)*

------
https://chatgpt.com/codex/tasks/task_b_68c19f6043388328bd45dbdcf3cfc408