### PR TITLE
Reset log parser after program completion

### DIFF
--- a/common/src/solana.rs
+++ b/common/src/solana.rs
@@ -120,6 +120,11 @@ pub fn is_success(log: &str) -> bool {
     log.trim_end().ends_with(" success")
 }
 
+/// Returns true for:  Program <PK> failed: ...
+pub fn is_failed(log: &str) -> bool {
+    log.contains(" failed:")
+}
+
 /// Returns true for:  Program <PK> invoke [...]
 pub fn is_invoke(log: &str) -> bool {
     log.contains(" invoke [")
@@ -147,6 +152,20 @@ mod tests {
         let log = "Program ABCD success";
         assert!(is_success(log));
         assert!(!is_invoke(log));
+    }
+
+    #[test]
+    fn failed_detection() {
+        let log = "Program ABCD failed: custom program error: 0x0";
+        assert!(is_failed(log));
+        assert!(!is_invoke(log));
+        assert!(!is_success(log));
+    }
+
+    #[test]
+    fn failed_non_match() {
+        let log = "Program log: something failed";
+        assert!(!is_failed(log));
     }
 
     #[test]

--- a/jupiter-v4/src/lib.rs
+++ b/jupiter-v4/src/lib.rs
@@ -1,4 +1,4 @@
-use common::solana::{get_fee_payer, get_signers, is_invoke, parse_invoke_depth, parse_program_data, parse_program_id};
+use common::solana::{get_fee_payer, get_signers, is_failed, is_invoke, is_success, parse_invoke_depth, parse_program_data, parse_program_id};
 use proto::pb::jupiter::v1 as pb;
 use substreams::errors::Error;
 use substreams_solana::pb::sf::solana::r#type::v1::{Block, ConfirmedTransaction, TransactionStatusMeta};
@@ -47,6 +47,9 @@ fn process_logs(tx_meta: &TransactionStatusMeta) -> Vec<pb::Instruction> {
                 // Continue to next log message as invoke logs don't contain program data
                 continue;
             }
+        } else if is_jupiter_program && (is_success(log_message) || is_failed(log_message)) {
+            is_invoked = false;
+            continue;
         }
 
         // Skip processing if not in Jupiter V4 context

--- a/meteora/amm/src/lib.rs
+++ b/meteora/amm/src/lib.rs
@@ -1,4 +1,4 @@
-use common::solana::{get_fee_payer, get_signers, is_invoke, parse_invoke_depth, parse_program_data, parse_program_id};
+use common::solana::{get_fee_payer, get_signers, is_failed, is_invoke, is_success, parse_invoke_depth, parse_program_data, parse_program_id};
 use proto::pb::meteora::amm::v1 as pb;
 use substreams::errors::Error;
 use substreams_solana::{
@@ -88,6 +88,8 @@ fn process_logs(tx_meta: &TransactionStatusMeta, program_id_bytes: &[u8]) -> Vec
                     logs.push(log_data);
                 }
             }
+        } else if match_program_id && (is_success(log_message) || is_failed(log_message)) {
+            is_invoked = false;
         } else if is_invoked {
             if let Some(log_data) = parse_log_data(log_message, program_id_bytes, 0) {
                 logs.push(log_data);

--- a/meteora_dllm/src/lib.rs
+++ b/meteora_dllm/src/lib.rs
@@ -1,4 +1,4 @@
-use common::solana::{get_fee_payer, get_signers, is_invoke, parse_invoke_depth, parse_program_data, parse_program_id};
+use common::solana::{get_fee_payer, get_signers, is_failed, is_invoke, is_success, parse_invoke_depth, parse_program_data, parse_program_id};
 use proto::pb::meteora::dllm::v1 as pb;
 use substreams::errors::Error;
 use substreams_solana::{
@@ -88,6 +88,8 @@ fn process_logs(tx_meta: &TransactionStatusMeta, program_id_bytes: &[u8]) -> Vec
                     logs.push(log_data);
                 }
             }
+        } else if match_program_id && (is_success(log_message) || is_failed(log_message)) {
+            is_invoked = false;
         } else if is_invoked {
             if let Some(log_data) = parse_log_data(log_message, program_id_bytes, 0) {
                 logs.push(log_data);

--- a/raydium-amm-v4/src/lib.rs
+++ b/raydium-amm-v4/src/lib.rs
@@ -1,4 +1,4 @@
-use common::solana::{get_fee_payer, get_signers, is_invoke, parse_invoke_depth, parse_program_id, parse_raydium_log};
+use common::solana::{get_fee_payer, get_signers, is_failed, is_invoke, is_success, parse_invoke_depth, parse_program_id, parse_raydium_log};
 use proto::pb::raydium::amm::v1 as pb;
 use substreams::errors::Error;
 use substreams_solana::{
@@ -90,6 +90,8 @@ fn process_logs(tx_meta: &TransactionStatusMeta, program_id_bytes: &[u8]) -> Vec
                     logs.push(log_data);
                 }
             }
+        } else if match_program_id && (is_success(log_message) || is_failed(log_message)) {
+            is_invoked = false;
         } else if is_invoked {
             // Process logs within an invoked context
             if let Some(log_data) = parse_log_data(log_message, program_id_bytes, 0) {

--- a/raydium-clmm/src/lib.rs
+++ b/raydium-clmm/src/lib.rs
@@ -1,4 +1,4 @@
-use common::solana::{get_fee_payer, get_signers, is_invoke, parse_invoke_depth, parse_program_data, parse_program_id};
+use common::solana::{get_fee_payer, get_signers, is_failed, is_invoke, is_success, parse_invoke_depth, parse_program_data, parse_program_id};
 use proto::pb::raydium::clmm::v1 as pb;
 use substreams::errors::Error;
 use substreams_solana::{
@@ -115,6 +115,8 @@ fn process_logs(tx_meta: &TransactionStatusMeta, program_id_bytes: &[u8]) -> Vec
                     logs.push(log_data);
                 }
             }
+        } else if match_program_id && (is_success(log_message) || is_failed(log_message)) {
+            is_invoked = false;
         } else if is_invoked {
             // substreams::log::debug!("Invoked, Log message: {}", log_message);
             if let Some(log_data) = parse_log_data(log_message, program_id_bytes, 0) {

--- a/raydium-cpmm/src/lib.rs
+++ b/raydium-cpmm/src/lib.rs
@@ -1,4 +1,4 @@
-use common::solana::{get_fee_payer, get_signers, is_invoke, parse_invoke_depth, parse_program_data, parse_program_id};
+use common::solana::{get_fee_payer, get_signers, is_failed, is_invoke, is_success, parse_invoke_depth, parse_program_data, parse_program_id};
 use proto::pb::raydium::cpmm::v1 as pb;
 use substreams::errors::Error;
 use substreams_solana::{
@@ -113,6 +113,8 @@ fn process_logs(tx_meta: &TransactionStatusMeta, program_id_bytes: &[u8]) -> Vec
                     logs.push(log_data);
                 }
             }
+        } else if match_program_id && (is_success(log_message) || is_failed(log_message)) {
+            is_invoked = false;
         } else if is_invoked {
             if let Some(log_data) = parse_log_data(log_message, program_id_bytes, 0) {
                 logs.push(log_data);

--- a/raydium-launchpad/src/lib.rs
+++ b/raydium-launchpad/src/lib.rs
@@ -1,4 +1,4 @@
-use common::solana::{get_fee_payer, get_signers, is_invoke, parse_invoke_depth, parse_program_data, parse_program_id};
+use common::solana::{get_fee_payer, get_signers, is_failed, is_invoke, is_success, parse_invoke_depth, parse_program_data, parse_program_id};
 use proto::pb::raydium::launchpad::v1 as pb;
 use substreams::errors::Error;
 use substreams_solana::{
@@ -176,6 +176,8 @@ fn process_logs(tx_meta: &TransactionStatusMeta, program_id_bytes: &[u8]) -> Vec
                     logs.push(log_data);
                 }
             }
+        } else if match_program_id && (is_success(log_message) || is_failed(log_message)) {
+            is_invoked = false;
         } else if is_invoked {
             if let Some(log_data) = parse_log_data(log_message, program_id_bytes, 0) {
                 logs.push(log_data);


### PR DESCRIPTION
## Summary
- add common `is_failed` log helper with tests
- reset invocation state after program `success` or `failed` in log parsers

## Testing
- `cargo test` *(fails: could not compile `proto` due to duplicate `meteora` modules)*

------
https://chatgpt.com/codex/tasks/task_b_68c1a3b22ec08328950a7c1bff437f2b