### PR TITLE
Handle Raydium Launchpad CPI events as instructions

### DIFF
--- a/proto/src/pb/raydium.launchpad.v1.rs
+++ b/proto/src/pb/raydium.launchpad.v1.rs
@@ -6,26 +6,24 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Events {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub transactions: ::prost::alloc::vec::Vec<Transaction>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Transaction {
-    #[prost(bytes="vec", tag="1")]
+    #[prost(bytes = "vec", tag = "1")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub fee_payer: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", repeated, tag="3")]
+    #[prost(bytes = "vec", repeated, tag = "3")]
     pub signers: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag = "4")]
     pub fee: u64,
-    #[prost(uint64, tag="5")]
+    #[prost(uint64, tag = "5")]
     pub compute_units_consumed: u64,
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub instructions: ::prost::alloc::vec::Vec<Instruction>,
-    #[prost(message, repeated, tag="7")]
-    pub logs: ::prost::alloc::vec::Vec<Log>,
 }
 /// -----------------------------------------------------------------------------
 /// Instruction + typed payloads
@@ -33,286 +31,269 @@ pub struct Transaction {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Instruction {
-    #[prost(bytes="vec", tag="1")]
+    #[prost(bytes = "vec", tag = "1")]
     pub program_id: ::prost::alloc::vec::Vec<u8>,
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag = "2")]
     pub stack_height: u32,
-    #[prost(oneof="instruction::Instruction", tags="3, 4, 5, 6")]
+    #[prost(oneof = "instruction::Instruction", tags = "3, 4, 5, 6, 7, 8, 9, 10")]
     pub instruction: ::core::option::Option<instruction::Instruction>,
 }
 /// Nested message and enum types in `Instruction`.
 pub mod instruction {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Instruction {
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         BuyExactIn(super::BuyExactInInstruction),
-        #[prost(message, tag="4")]
+        #[prost(message, tag = "4")]
         BuyExactOut(super::BuyExactOutInstruction),
-        #[prost(message, tag="5")]
+        #[prost(message, tag = "5")]
         SellExactIn(super::SellExactInInstruction),
-        #[prost(message, tag="6")]
+        #[prost(message, tag = "6")]
         SellExactOut(super::SellExactOutInstruction),
+        #[prost(message, tag = "7")]
+        TradeEvent(super::TradeEvent),
+        #[prost(message, tag = "8")]
+        ClaimVestedEvent(super::ClaimVestedEvent),
+        #[prost(message, tag = "9")]
+        CreateVestingEvent(super::CreateVestingEvent),
+        #[prost(message, tag = "10")]
+        PoolCreateEvent(super::PoolCreateEvent),
     }
 }
 /// Accounts shared by trade instructions
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TradeAccounts {
-    #[prost(bytes="vec", tag="1")]
+    #[prost(bytes = "vec", tag = "1")]
     pub payer: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub authority: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes = "vec", tag = "3")]
     pub global_config: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="4")]
+    #[prost(bytes = "vec", tag = "4")]
     pub platform_config: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="5")]
+    #[prost(bytes = "vec", tag = "5")]
     pub pool_state: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="6")]
+    #[prost(bytes = "vec", tag = "6")]
     pub user_base_token: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="7")]
+    #[prost(bytes = "vec", tag = "7")]
     pub user_quote_token: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="8")]
+    #[prost(bytes = "vec", tag = "8")]
     pub base_vault: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="9")]
+    #[prost(bytes = "vec", tag = "9")]
     pub quote_vault: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="10")]
+    #[prost(bytes = "vec", tag = "10")]
     pub base_token_mint: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="11")]
+    #[prost(bytes = "vec", tag = "11")]
     pub quote_token_mint: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="12")]
+    #[prost(bytes = "vec", tag = "12")]
     pub base_token_program: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="13")]
+    #[prost(bytes = "vec", tag = "13")]
     pub quote_token_program: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="14")]
+    #[prost(bytes = "vec", tag = "14")]
     pub event_authority: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="15")]
+    #[prost(bytes = "vec", tag = "15")]
     pub program: ::prost::alloc::vec::Vec<u8>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BuyExactInInstruction {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub accounts: ::core::option::Option<TradeAccounts>,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub amount_in: u64,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub minimum_amount_out: u64,
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag = "4")]
     pub share_fee_rate: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BuyExactOutInstruction {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub accounts: ::core::option::Option<TradeAccounts>,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub amount_out: u64,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub maximum_amount_in: u64,
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag = "4")]
     pub share_fee_rate: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SellExactInInstruction {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub accounts: ::core::option::Option<TradeAccounts>,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub amount_in: u64,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub minimum_amount_out: u64,
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag = "4")]
     pub share_fee_rate: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SellExactOutInstruction {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub accounts: ::core::option::Option<TradeAccounts>,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub amount_out: u64,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub maximum_amount_in: u64,
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag = "4")]
     pub share_fee_rate: u64,
 }
 /// -----------------------------------------------------------------------------
-/// Logs
+/// Events
 /// -----------------------------------------------------------------------------
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Log {
-    #[prost(bytes="vec", tag="1")]
-    pub program_id: ::prost::alloc::vec::Vec<u8>,
-    #[prost(uint32, tag="2")]
-    pub invoke_depth: u32,
-    #[prost(oneof="log::Log", tags="3, 4, 5, 6")]
-    pub log: ::core::option::Option<log::Log>,
-}
-/// Nested message and enum types in `Log`.
-pub mod log {
-    #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Log {
-        #[prost(message, tag="3")]
-        ClaimVested(super::ClaimVestedLog),
-        #[prost(message, tag="4")]
-        CreateVesting(super::CreateVestingLog),
-        #[prost(message, tag="5")]
-        PoolCreate(super::PoolCreateLog),
-        #[prost(message, tag="6")]
-        Trade(super::TradeLog),
-    }
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ClaimVestedLog {
-    #[prost(bytes="vec", tag="1")]
+pub struct ClaimVestedEvent {
+    #[prost(bytes = "vec", tag = "1")]
     pub pool_state: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub beneficiary: ::prost::alloc::vec::Vec<u8>,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub claim_amount: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CreateVestingLog {
-    #[prost(bytes="vec", tag="1")]
+pub struct CreateVestingEvent {
+    #[prost(bytes = "vec", tag = "1")]
     pub pool_state: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub beneficiary: ::prost::alloc::vec::Vec<u8>,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub share_amount: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PoolCreateLog {
-    #[prost(bytes="vec", tag="1")]
+pub struct PoolCreateEvent {
+    #[prost(bytes = "vec", tag = "1")]
     pub pool_state: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="2")]
+    #[prost(bytes = "vec", tag = "2")]
     pub creator: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes = "vec", tag = "3")]
     pub config: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub base_mint_param: ::core::option::Option<MintParams>,
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub curve_param: ::core::option::Option<CurveParams>,
-    #[prost(message, optional, tag="6")]
+    #[prost(message, optional, tag = "6")]
     pub vesting_param: ::core::option::Option<VestingParams>,
-    #[prost(enumeration="AmmCreatorFeeOn", tag="7")]
+    #[prost(enumeration = "AmmCreatorFeeOn", tag = "7")]
     pub amm_fee_on: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintParams {
-    #[prost(uint32, tag="1")]
+    #[prost(uint32, tag = "1")]
     pub decimals: u32,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub name: ::prost::alloc::string::String,
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub symbol: ::prost::alloc::string::String,
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub uri: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct CurveParams {
-    #[prost(oneof="curve_params::Curve", tags="1, 2, 3")]
+    #[prost(oneof = "curve_params::Curve", tags = "1, 2, 3")]
     pub curve: ::core::option::Option<curve_params::Curve>,
 }
 /// Nested message and enum types in `CurveParams`.
 pub mod curve_params {
     #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
     pub enum Curve {
-        #[prost(message, tag="1")]
+        #[prost(message, tag = "1")]
         Constant(super::ConstantCurve),
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         Fixed(super::FixedCurve),
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         Linear(super::LinearCurve),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ConstantCurve {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub supply: u64,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub total_base_sell: u64,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub total_quote_fund_raising: u64,
-    #[prost(uint32, tag="4")]
+    #[prost(uint32, tag = "4")]
     pub migrate_type: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct FixedCurve {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub supply: u64,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub total_quote_fund_raising: u64,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub migrate_type: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct LinearCurve {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub supply: u64,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub total_quote_fund_raising: u64,
-    #[prost(uint32, tag="3")]
+    #[prost(uint32, tag = "3")]
     pub migrate_type: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct VestingParams {
-    #[prost(uint64, tag="1")]
+    #[prost(uint64, tag = "1")]
     pub total_locked_amount: u64,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub cliff_period: u64,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub unlock_period: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TradeLog {
-    #[prost(bytes="vec", tag="1")]
+pub struct TradeEvent {
+    #[prost(bytes = "vec", tag = "1")]
     pub pool_state: ::prost::alloc::vec::Vec<u8>,
-    #[prost(uint64, tag="2")]
+    #[prost(uint64, tag = "2")]
     pub total_base_sell: u64,
-    #[prost(uint64, tag="3")]
+    #[prost(uint64, tag = "3")]
     pub virtual_base: u64,
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag = "4")]
     pub virtual_quote: u64,
-    #[prost(uint64, tag="5")]
+    #[prost(uint64, tag = "5")]
     pub real_base_before: u64,
-    #[prost(uint64, tag="6")]
+    #[prost(uint64, tag = "6")]
     pub real_quote_before: u64,
-    #[prost(uint64, tag="7")]
+    #[prost(uint64, tag = "7")]
     pub real_base_after: u64,
-    #[prost(uint64, tag="8")]
+    #[prost(uint64, tag = "8")]
     pub real_quote_after: u64,
-    #[prost(uint64, tag="9")]
+    #[prost(uint64, tag = "9")]
     pub amount_in: u64,
-    #[prost(uint64, tag="10")]
+    #[prost(uint64, tag = "10")]
     pub amount_out: u64,
-    #[prost(uint64, tag="11")]
+    #[prost(uint64, tag = "11")]
     pub protocol_fee: u64,
-    #[prost(uint64, tag="12")]
+    #[prost(uint64, tag = "12")]
     pub platform_fee: u64,
-    #[prost(uint64, tag="13")]
+    #[prost(uint64, tag = "13")]
     pub creator_fee: u64,
-    #[prost(uint64, tag="14")]
+    #[prost(uint64, tag = "14")]
     pub share_fee: u64,
-    #[prost(enumeration="TradeDirection", tag="15")]
+    #[prost(enumeration = "TradeDirection", tag = "15")]
     pub trade_direction: i32,
-    #[prost(enumeration="PoolStatus", tag="16")]
+    #[prost(enumeration = "PoolStatus", tag = "16")]
     pub pool_status: i32,
-    #[prost(bool, tag="17")]
+    #[prost(bool, tag = "17")]
     pub exact_in: bool,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/proto/v1/raydium-launchpad.proto
+++ b/proto/v1/raydium-launchpad.proto
@@ -16,7 +16,6 @@ message Transaction {
   uint64 fee                        = 4;
   uint64 compute_units_consumed     = 5;
   repeated Instruction instructions = 6;
-  repeated Log logs                 = 7;
 }
 
 // -----------------------------------------------------------------------------
@@ -30,6 +29,10 @@ message Instruction {
     BuyExactOutInstruction buy_exact_out   = 4;
     SellExactInInstruction sell_exact_in   = 5;
     SellExactOutInstruction sell_exact_out = 6;
+    TradeEvent trade_event                 = 7;
+    ClaimVestedEvent claim_vested_event    = 8;
+    CreateVestingEvent create_vesting_event = 9;
+    PoolCreateEvent pool_create_event      = 10;
   }
 }
 
@@ -81,32 +84,21 @@ message SellExactOutInstruction {
 }
 
 // -----------------------------------------------------------------------------
-// Logs
+// Events
 // -----------------------------------------------------------------------------
-message Log {
-  bytes program_id = 1;
-  uint32 invoke_depth = 2;
-  oneof log {
-    ClaimVestedLog claim_vested = 3;
-    CreateVestingLog create_vesting = 4;
-    PoolCreateLog pool_create = 5;
-    TradeLog trade = 6;
-  }
-}
-
-message ClaimVestedLog {
+message ClaimVestedEvent {
   bytes pool_state = 1;
   bytes beneficiary = 2;
   uint64 claim_amount = 3;
 }
 
-message CreateVestingLog {
+message CreateVestingEvent {
   bytes pool_state = 1;
   bytes beneficiary = 2;
   uint64 share_amount = 3;
 }
 
-message PoolCreateLog {
+message PoolCreateEvent {
   bytes pool_state = 1;
   bytes creator = 2;
   bytes config = 3;
@@ -161,7 +153,7 @@ enum AmmCreatorFeeOn {
   BOTH_TOKEN = 1;
 }
 
-message TradeLog {
+message TradeEvent {
   bytes pool_state       = 1;
   uint64 total_base_sell = 2;
   uint64 virtual_base    = 3;

--- a/raydium/launchpad/src/lib.rs
+++ b/raydium/launchpad/src/lib.rs
@@ -1,9 +1,9 @@
-use common::solana::{get_fee_payer, get_signers, is_failed, is_invoke, is_success, parse_invoke_depth, parse_program_data, parse_program_id};
+use common::solana::{get_fee_payer, get_signers};
 use proto::pb::raydium::launchpad::v1 as pb;
 use substreams::errors::Error;
 use substreams_solana::{
     block_view::InstructionView,
-    pb::sf::solana::r#type::v1::{Block, ConfirmedTransaction, TransactionStatusMeta},
+    pb::sf::solana::r#type::v1::{Block, ConfirmedTransaction},
 };
 use substreams_solana_idls::raydium;
 
@@ -18,9 +18,8 @@ fn process_transaction(tx: ConfirmedTransaction) -> Option<pb::Transaction> {
     let tx_meta = tx.meta.as_ref()?;
 
     let instructions: Vec<pb::Instruction> = tx.walk_instructions().filter_map(|iv| process_instruction(&iv)).collect();
-    let logs = process_logs(tx_meta, &raydium::launchpad::PROGRAM_ID.to_vec());
 
-    if instructions.is_empty() && logs.is_empty() {
+    if instructions.is_empty() {
         return None;
     }
 
@@ -31,7 +30,6 @@ fn process_transaction(tx: ConfirmedTransaction) -> Option<pb::Transaction> {
         fee_payer: get_fee_payer(&tx).unwrap_or_default(),
         signers: get_signers(&tx).unwrap_or_default(),
         instructions,
-        logs,
     })
 }
 
@@ -39,6 +37,107 @@ fn process_instruction(ix: &InstructionView) -> Option<pb::Instruction> {
     let program_id = ix.program_id().0;
     if program_id != &raydium::launchpad::PROGRAM_ID {
         return None;
+    }
+    if let Ok(event) = raydium::launchpad::events::unpack(ix.data()) {
+        return match event {
+            raydium::launchpad::events::RaydiumLaunchpadEvent::TradeEvent(event) => Some(pb::Instruction {
+                program_id: program_id.to_vec(),
+                stack_height: ix.stack_height(),
+                instruction: Some(pb::instruction::Instruction::TradeEvent(pb::TradeEvent {
+                    pool_state: event.pool_state.to_bytes().to_vec(),
+                    total_base_sell: event.total_base_sell,
+                    virtual_base: event.virtual_base,
+                    virtual_quote: event.virtual_quote,
+                    real_base_before: event.real_base_before,
+                    real_quote_before: event.real_quote_before,
+                    real_base_after: event.real_base_after,
+                    real_quote_after: event.real_quote_after,
+                    amount_in: event.amount_in,
+                    amount_out: event.amount_out,
+                    protocol_fee: event.protocol_fee,
+                    platform_fee: event.platform_fee,
+                    creator_fee: event.creator_fee,
+                    share_fee: event.share_fee,
+                    trade_direction: match event.trade_direction {
+                        raydium::launchpad::events::TradeDirection::Buy => pb::TradeDirection::Buy as i32,
+                        raydium::launchpad::events::TradeDirection::Sell => pb::TradeDirection::Sell as i32,
+                    },
+                    pool_status: match event.pool_status {
+                        raydium::launchpad::events::PoolStatus::Fund => pb::PoolStatus::Fund as i32,
+                        raydium::launchpad::events::PoolStatus::Migrate => pb::PoolStatus::Migrate as i32,
+                        raydium::launchpad::events::PoolStatus::Trade => pb::PoolStatus::Trade as i32,
+                    },
+                    exact_in: event.exact_in,
+                })),
+            }),
+            raydium::launchpad::events::RaydiumLaunchpadEvent::ClaimVestedEvent(event) => Some(pb::Instruction {
+                program_id: program_id.to_vec(),
+                stack_height: ix.stack_height(),
+                instruction: Some(pb::instruction::Instruction::ClaimVestedEvent(pb::ClaimVestedEvent {
+                    pool_state: event.pool_state.to_bytes().to_vec(),
+                    beneficiary: event.beneficiary.to_bytes().to_vec(),
+                    claim_amount: event.claim_amount,
+                })),
+            }),
+            raydium::launchpad::events::RaydiumLaunchpadEvent::CreateVestingEvent(event) => Some(pb::Instruction {
+                program_id: program_id.to_vec(),
+                stack_height: ix.stack_height(),
+                instruction: Some(pb::instruction::Instruction::CreateVestingEvent(pb::CreateVestingEvent {
+                    pool_state: event.pool_state.to_bytes().to_vec(),
+                    beneficiary: event.beneficiary.to_bytes().to_vec(),
+                    share_amount: event.share_amount,
+                })),
+            }),
+            raydium::launchpad::events::RaydiumLaunchpadEvent::PoolCreateEvent(event) => Some(pb::Instruction {
+                program_id: program_id.to_vec(),
+                stack_height: ix.stack_height(),
+                instruction: Some(pb::instruction::Instruction::PoolCreateEvent(pb::PoolCreateEvent {
+                    pool_state: event.pool_state.to_bytes().to_vec(),
+                    creator: event.creator.to_bytes().to_vec(),
+                    config: event.config.to_bytes().to_vec(),
+                    base_mint_param: Some(pb::MintParams {
+                        decimals: event.base_mint_param.decimals as u32,
+                        name: event.base_mint_param.name,
+                        symbol: event.base_mint_param.symbol,
+                        uri: event.base_mint_param.uri,
+                    }),
+                    curve_param: Some(match event.curve_param {
+                        raydium::launchpad::events::CurveParams::Constant { data } => pb::CurveParams {
+                            curve: Some(pb::curve_params::Curve::Constant(pb::ConstantCurve {
+                                supply: data.supply,
+                                total_base_sell: data.total_base_sell,
+                                total_quote_fund_raising: data.total_quote_fund_raising,
+                                migrate_type: data.migrate_type as u32,
+                            })),
+                        },
+                        raydium::launchpad::events::CurveParams::Fixed { data } => pb::CurveParams {
+                            curve: Some(pb::curve_params::Curve::Fixed(pb::FixedCurve {
+                                supply: data.supply,
+                                total_quote_fund_raising: data.total_quote_fund_raising,
+                                migrate_type: data.migrate_type as u32,
+                            })),
+                        },
+                        raydium::launchpad::events::CurveParams::Linear { data } => pb::CurveParams {
+                            curve: Some(pb::curve_params::Curve::Linear(pb::LinearCurve {
+                                supply: data.supply,
+                                total_quote_fund_raising: data.total_quote_fund_raising,
+                                migrate_type: data.migrate_type as u32,
+                            })),
+                        },
+                    }),
+                    vesting_param: Some(pb::VestingParams {
+                        total_locked_amount: event.vesting_param.total_locked_amount,
+                        cliff_period: event.vesting_param.cliff_period,
+                        unlock_period: event.vesting_param.unlock_period,
+                    }),
+                    amm_fee_on: match event.amm_fee_on {
+                        raydium::launchpad::events::AmmCreatorFeeOn::QuoteToken => pb::AmmCreatorFeeOn::QuoteToken as i32,
+                        raydium::launchpad::events::AmmCreatorFeeOn::BothToken => pb::AmmCreatorFeeOn::BothToken as i32,
+                    },
+                })),
+            }),
+            raydium::launchpad::events::RaydiumLaunchpadEvent::Unknown => None,
+        };
     }
 
     match raydium::launchpad::instructions::unpack(ix.data()) {
@@ -158,135 +257,6 @@ fn process_instruction(ix: &InstructionView) -> Option<pb::Instruction> {
                 })),
             })
         }
-        _ => None,
-    }
-}
-
-fn process_logs(tx_meta: &TransactionStatusMeta, program_id_bytes: &[u8]) -> Vec<pb::Log> {
-    let mut logs = Vec::new();
-    let mut is_invoked = false;
-
-    for log_message in tx_meta.log_messages.iter() {
-        let match_program_id = parse_program_id(log_message).map_or(false, |id| id == program_id_bytes.to_vec());
-
-        if is_invoke(log_message) && match_program_id {
-            if let Some(invoke_depth) = parse_invoke_depth(log_message) {
-                is_invoked = true;
-                if let Some(log_data) = parse_log_data(log_message, program_id_bytes, invoke_depth) {
-                    logs.push(log_data);
-                }
-            }
-        } else if match_program_id && (is_success(log_message) || is_failed(log_message)) {
-            is_invoked = false;
-        } else if is_invoked {
-            if let Some(log_data) = parse_log_data(log_message, program_id_bytes, 0) {
-                logs.push(log_data);
-            }
-        }
-    }
-
-    logs
-}
-
-fn parse_log_data(log_message: &str, program_id_bytes: &[u8], invoke_depth: u32) -> Option<pb::Log> {
-    let data = parse_program_data(log_message)?;
-    match raydium::launchpad::events::unpack(data.as_slice()) {
-        Ok(raydium::launchpad::events::RaydiumLaunchpadEvent::TradeEvent(event)) => Some(pb::Log {
-            program_id: program_id_bytes.to_vec(),
-            invoke_depth,
-            log: Some(pb::log::Log::Trade(pb::TradeLog {
-                pool_state: event.pool_state.to_bytes().to_vec(),
-                total_base_sell: event.total_base_sell,
-                virtual_base: event.virtual_base,
-                virtual_quote: event.virtual_quote,
-                real_base_before: event.real_base_before,
-                real_quote_before: event.real_quote_before,
-                real_base_after: event.real_base_after,
-                real_quote_after: event.real_quote_after,
-                amount_in: event.amount_in,
-                amount_out: event.amount_out,
-                protocol_fee: event.protocol_fee,
-                platform_fee: event.platform_fee,
-                creator_fee: event.creator_fee,
-                share_fee: event.share_fee,
-                trade_direction: match event.trade_direction {
-                    raydium::launchpad::events::TradeDirection::Buy => pb::TradeDirection::Buy as i32,
-                    raydium::launchpad::events::TradeDirection::Sell => pb::TradeDirection::Sell as i32,
-                },
-                pool_status: match event.pool_status {
-                    raydium::launchpad::events::PoolStatus::Fund => pb::PoolStatus::Fund as i32,
-                    raydium::launchpad::events::PoolStatus::Migrate => pb::PoolStatus::Migrate as i32,
-                    raydium::launchpad::events::PoolStatus::Trade => pb::PoolStatus::Trade as i32,
-                },
-                exact_in: event.exact_in,
-            })),
-        }),
-        Ok(raydium::launchpad::events::RaydiumLaunchpadEvent::ClaimVestedEvent(event)) => Some(pb::Log {
-            program_id: program_id_bytes.to_vec(),
-            invoke_depth,
-            log: Some(pb::log::Log::ClaimVested(pb::ClaimVestedLog {
-                pool_state: event.pool_state.to_bytes().to_vec(),
-                beneficiary: event.beneficiary.to_bytes().to_vec(),
-                claim_amount: event.claim_amount,
-            })),
-        }),
-        Ok(raydium::launchpad::events::RaydiumLaunchpadEvent::CreateVestingEvent(event)) => Some(pb::Log {
-            program_id: program_id_bytes.to_vec(),
-            invoke_depth,
-            log: Some(pb::log::Log::CreateVesting(pb::CreateVestingLog {
-                pool_state: event.pool_state.to_bytes().to_vec(),
-                beneficiary: event.beneficiary.to_bytes().to_vec(),
-                share_amount: event.share_amount,
-            })),
-        }),
-        Ok(raydium::launchpad::events::RaydiumLaunchpadEvent::PoolCreateEvent(event)) => Some(pb::Log {
-            program_id: program_id_bytes.to_vec(),
-            invoke_depth,
-            log: Some(pb::log::Log::PoolCreate(pb::PoolCreateLog {
-                pool_state: event.pool_state.to_bytes().to_vec(),
-                creator: event.creator.to_bytes().to_vec(),
-                config: event.config.to_bytes().to_vec(),
-                base_mint_param: Some(pb::MintParams {
-                    decimals: event.base_mint_param.decimals as u32,
-                    name: event.base_mint_param.name,
-                    symbol: event.base_mint_param.symbol,
-                    uri: event.base_mint_param.uri,
-                }),
-                curve_param: Some(match event.curve_param {
-                    raydium::launchpad::events::CurveParams::Constant { data } => pb::CurveParams {
-                        curve: Some(pb::curve_params::Curve::Constant(pb::ConstantCurve {
-                            supply: data.supply,
-                            total_base_sell: data.total_base_sell,
-                            total_quote_fund_raising: data.total_quote_fund_raising,
-                            migrate_type: data.migrate_type as u32,
-                        })),
-                    },
-                    raydium::launchpad::events::CurveParams::Fixed { data } => pb::CurveParams {
-                        curve: Some(pb::curve_params::Curve::Fixed(pb::FixedCurve {
-                            supply: data.supply,
-                            total_quote_fund_raising: data.total_quote_fund_raising,
-                            migrate_type: data.migrate_type as u32,
-                        })),
-                    },
-                    raydium::launchpad::events::CurveParams::Linear { data } => pb::CurveParams {
-                        curve: Some(pb::curve_params::Curve::Linear(pb::LinearCurve {
-                            supply: data.supply,
-                            total_quote_fund_raising: data.total_quote_fund_raising,
-                            migrate_type: data.migrate_type as u32,
-                        })),
-                    },
-                }),
-                vesting_param: Some(pb::VestingParams {
-                    total_locked_amount: event.vesting_param.total_locked_amount,
-                    cliff_period: event.vesting_param.cliff_period,
-                    unlock_period: event.vesting_param.unlock_period,
-                }),
-                amm_fee_on: match event.amm_fee_on {
-                    raydium::launchpad::events::AmmCreatorFeeOn::QuoteToken => pb::AmmCreatorFeeOn::QuoteToken as i32,
-                    raydium::launchpad::events::AmmCreatorFeeOn::BothToken => pb::AmmCreatorFeeOn::BothToken as i32,
-                },
-            })),
-        }),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- treat Raydium Launchpad anchor events as instructions
- replace log parsing with direct event decoding
- extend protobufs for launchpad events and remove log field

## Testing
- `cargo test -p proto`
- `cargo test -p raydium_launchpad`


------
https://chatgpt.com/codex/tasks/task_b_68c361d5d54883288bc91822ff6eaa53