### PR TITLE
feat: add raydium and meteora dex support

### DIFF
--- a/clickhouse-solana-dex/schema.1.events.meteora-amm.sql
+++ b/clickhouse-solana-dex/schema.1.events.meteora-amm.sql
@@ -1,0 +1,10 @@
+-- Meteora AMM Swap --
+CREATE TABLE IF NOT EXISTS meteora_amm_swap AS base_events
+COMMENT 'Meteora AMM Swap';
+ALTER TABLE meteora_amm_swap
+    ADD COLUMN IF NOT EXISTS user        FixedString(44) COMMENT 'User account',
+    ADD COLUMN IF NOT EXISTS pool        FixedString(44) COMMENT 'Pool account',
+    ADD COLUMN IF NOT EXISTS input_mint  FixedString(44) COMMENT 'Input token account',
+    ADD COLUMN IF NOT EXISTS output_mint FixedString(44) COMMENT 'Output token account',
+    ADD COLUMN IF NOT EXISTS amount_in   UInt64 COMMENT 'Amount of tokens in',
+    ADD COLUMN IF NOT EXISTS amount_out  UInt64 COMMENT 'Amount of tokens out';

--- a/clickhouse-solana-dex/schema.1.events.meteora-daam.sql
+++ b/clickhouse-solana-dex/schema.1.events.meteora-daam.sql
@@ -1,0 +1,10 @@
+-- Meteora DAAM Swap --
+CREATE TABLE IF NOT EXISTS meteora_daam_swap AS base_events
+COMMENT 'Meteora DAAM Swap';
+ALTER TABLE meteora_daam_swap
+    ADD COLUMN IF NOT EXISTS payer       FixedString(44) COMMENT 'User account',
+    ADD COLUMN IF NOT EXISTS pool        FixedString(44) COMMENT 'Pool account',
+    ADD COLUMN IF NOT EXISTS input_mint  FixedString(44) COMMENT 'Input token mint',
+    ADD COLUMN IF NOT EXISTS output_mint FixedString(44) COMMENT 'Output token mint',
+    ADD COLUMN IF NOT EXISTS amount_in   UInt64 COMMENT 'Amount of tokens in',
+    ADD COLUMN IF NOT EXISTS amount_out  UInt64 COMMENT 'Amount of tokens out';

--- a/clickhouse-solana-dex/schema.1.events.meteora-dllm.sql
+++ b/clickhouse-solana-dex/schema.1.events.meteora-dllm.sql
@@ -1,0 +1,10 @@
+-- Meteora DLLM Swap --
+CREATE TABLE IF NOT EXISTS meteora_dllm_swap AS base_events
+COMMENT 'Meteora DLLM Swap';
+ALTER TABLE meteora_dllm_swap
+    ADD COLUMN IF NOT EXISTS user        FixedString(44) COMMENT 'User account',
+    ADD COLUMN IF NOT EXISTS lb_pair     FixedString(44) COMMENT 'Liquidity pair',
+    ADD COLUMN IF NOT EXISTS input_mint  FixedString(44) COMMENT 'Input token mint',
+    ADD COLUMN IF NOT EXISTS output_mint FixedString(44) COMMENT 'Output token mint',
+    ADD COLUMN IF NOT EXISTS amount_in   UInt64 COMMENT 'Amount of tokens in',
+    ADD COLUMN IF NOT EXISTS amount_out  UInt64 COMMENT 'Amount of tokens out';

--- a/clickhouse-solana-dex/schema.1.events.raydium-clmm.sql
+++ b/clickhouse-solana-dex/schema.1.events.raydium-clmm.sql
@@ -1,0 +1,10 @@
+-- Raydium CLMM Swap --
+CREATE TABLE IF NOT EXISTS raydium_clmm_swap AS base_events
+COMMENT 'Raydium CLMM Swap';
+ALTER TABLE raydium_clmm_swap
+    ADD COLUMN IF NOT EXISTS payer        FixedString(44) COMMENT 'User account',
+    ADD COLUMN IF NOT EXISTS pool_state   FixedString(44) COMMENT 'Pool state account',
+    ADD COLUMN IF NOT EXISTS input_mint   FixedString(44) COMMENT 'Input token mint or vault',
+    ADD COLUMN IF NOT EXISTS output_mint  FixedString(44) COMMENT 'Output token mint or vault',
+    ADD COLUMN IF NOT EXISTS amount_in    UInt64 COMMENT 'Amount of tokens in',
+    ADD COLUMN IF NOT EXISTS amount_out   UInt64 COMMENT 'Amount of tokens out';

--- a/clickhouse-solana-dex/schema.1.events.raydium-cpmm.sql
+++ b/clickhouse-solana-dex/schema.1.events.raydium-cpmm.sql
@@ -1,0 +1,12 @@
+-- Raydium CPMM Swap --
+CREATE TABLE IF NOT EXISTS raydium_cpmm_swap_base_in AS base_events
+COMMENT 'Raydium CPMM Swap';
+ALTER TABLE raydium_cpmm_swap_base_in
+    ADD COLUMN IF NOT EXISTS payer               FixedString(44) COMMENT 'User account',
+    ADD COLUMN IF NOT EXISTS pool_state          FixedString(44) COMMENT 'Pool state account',
+    ADD COLUMN IF NOT EXISTS input_token_mint    FixedString(44) COMMENT 'Input token mint',
+    ADD COLUMN IF NOT EXISTS output_token_mint   FixedString(44) COMMENT 'Output token mint',
+    ADD COLUMN IF NOT EXISTS amount_in           UInt64 COMMENT 'Amount of tokens in',
+    ADD COLUMN IF NOT EXISTS amount_out          UInt64 COMMENT 'Amount of tokens out';
+
+CREATE TABLE IF NOT EXISTS raydium_cpmm_swap_base_out AS raydium_cpmm_swap_base_in;

--- a/clickhouse-solana-dex/schema.1.events.raydium-launchpad.sql
+++ b/clickhouse-solana-dex/schema.1.events.raydium-launchpad.sql
@@ -1,0 +1,13 @@
+-- Raydium Launchpad Trade Events --
+CREATE TABLE IF NOT EXISTS raydium_launchpad_buy AS base_events
+COMMENT 'Raydium Launchpad Buy';
+ALTER TABLE raydium_launchpad_buy
+    ADD COLUMN IF NOT EXISTS payer             FixedString(44) COMMENT 'User account',
+    ADD COLUMN IF NOT EXISTS pool_state        FixedString(44) COMMENT 'Pool state account',
+    ADD COLUMN IF NOT EXISTS base_token_mint   FixedString(44) COMMENT 'Base token mint',
+    ADD COLUMN IF NOT EXISTS quote_token_mint  FixedString(44) COMMENT 'Quote token mint',
+    ADD COLUMN IF NOT EXISTS amount_in         UInt64 COMMENT 'Amount of tokens in',
+    ADD COLUMN IF NOT EXISTS amount_out        UInt64 COMMENT 'Amount of tokens out',
+    ADD COLUMN IF NOT EXISTS exact_in          Bool COMMENT 'Whether trade is exact in';
+
+CREATE TABLE IF NOT EXISTS raydium_launchpad_sell AS raydium_launchpad_buy;

--- a/clickhouse-solana-dex/schema.2.view.swaps.sql
+++ b/clickhouse-solana-dex/schema.2.view.swaps.sql
@@ -305,3 +305,253 @@ SELECT
 FROM pumpfun_amm_sell AS s
 -- ignore dust swaps (typically trying to disort the price)
 WHERE input_amount > 1 AND output_amount > 1;
+
+/* ──────────────────────────────────────────────────────────────────────────
+   1.  Raydium CPMM → swaps
+   ────────────────────────────────────────────────────────────────────────── */
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_raydium_cpmm_swap_base_in
+TO swaps AS
+SELECT
+    block_num,
+    block_hash,
+    timestamp,
+
+    transaction_index,
+    instruction_index,
+
+    signature,
+    fee_payer,
+    signers_raw,
+    fee,
+    compute_units_consumed,
+
+    program_id,
+    stack_height,
+
+    payer AS user,
+    program_id AS amm,
+    pool_state AS amm_pool,
+    input_token_mint AS input_mint,
+    amount_in AS input_amount,
+    output_token_mint AS output_mint,
+    amount_out AS output_amount
+FROM raydium_cpmm_swap_base_in AS s
+WHERE input_amount > 1 AND output_amount > 1;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_raydium_cpmm_swap_base_out
+TO swaps AS
+SELECT
+    block_num,
+    block_hash,
+    timestamp,
+
+    transaction_index,
+    instruction_index,
+
+    signature,
+    fee_payer,
+    signers_raw,
+    fee,
+    compute_units_consumed,
+
+    program_id,
+    stack_height,
+
+    payer AS user,
+    program_id AS amm,
+    pool_state AS amm_pool,
+    input_token_mint AS input_mint,
+    amount_in AS input_amount,
+    output_token_mint AS output_mint,
+    amount_out AS output_amount
+FROM raydium_cpmm_swap_base_out AS s
+WHERE input_amount > 1 AND output_amount > 1;
+
+/* ──────────────────────────────────────────────────────────────────────────
+   1.  Raydium CLMM → swaps
+   ────────────────────────────────────────────────────────────────────────── */
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_raydium_clmm_swap
+TO swaps AS
+SELECT
+    block_num,
+    block_hash,
+    timestamp,
+
+    transaction_index,
+    instruction_index,
+
+    signature,
+    fee_payer,
+    signers_raw,
+    fee,
+    compute_units_consumed,
+
+    program_id,
+    stack_height,
+
+    payer AS user,
+    program_id AS amm,
+    pool_state AS amm_pool,
+    input_mint,
+    amount_in AS input_amount,
+    output_mint,
+    amount_out AS output_amount
+FROM raydium_clmm_swap AS s
+WHERE input_amount > 1 AND output_amount > 1;
+
+/* ──────────────────────────────────────────────────────────────────────────
+   1.  Raydium Launchpad → swaps
+   ────────────────────────────────────────────────────────────────────────── */
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_raydium_launchpad_buy
+TO swaps AS
+SELECT
+    block_num,
+    block_hash,
+    timestamp,
+
+    transaction_index,
+    instruction_index,
+
+    signature,
+    fee_payer,
+    signers_raw,
+    fee,
+    compute_units_consumed,
+
+    program_id,
+    stack_height,
+
+    payer AS user,
+    program_id AS amm,
+    pool_state AS amm_pool,
+    quote_token_mint AS input_mint,
+    amount_in AS input_amount,
+    base_token_mint AS output_mint,
+    amount_out AS output_amount
+FROM raydium_launchpad_buy AS s
+WHERE input_amount > 1 AND output_amount > 1;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_raydium_launchpad_sell
+TO swaps AS
+SELECT
+    block_num,
+    block_hash,
+    timestamp,
+
+    transaction_index,
+    instruction_index,
+
+    signature,
+    fee_payer,
+    signers_raw,
+    fee,
+    compute_units_consumed,
+
+    program_id,
+    stack_height,
+
+    payer AS user,
+    program_id AS amm,
+    pool_state AS amm_pool,
+    base_token_mint AS input_mint,
+    amount_in AS input_amount,
+    quote_token_mint AS output_mint,
+    amount_out AS output_amount
+FROM raydium_launchpad_sell AS s
+WHERE input_amount > 1 AND output_amount > 1;
+
+/* ──────────────────────────────────────────────────────────────────────────
+   1.  Meteora DLLM → swaps
+   ────────────────────────────────────────────────────────────────────────── */
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_meteora_dllm_swap
+TO swaps AS
+SELECT
+    block_num,
+    block_hash,
+    timestamp,
+
+    transaction_index,
+    instruction_index,
+
+    signature,
+    fee_payer,
+    signers_raw,
+    fee,
+    compute_units_consumed,
+
+    program_id,
+    stack_height,
+
+    user,
+    program_id AS amm,
+    lb_pair AS amm_pool,
+    input_mint,
+    amount_in AS input_amount,
+    output_mint,
+    amount_out AS output_amount
+FROM meteora_dllm_swap AS s
+WHERE input_amount > 1 AND output_amount > 1;
+
+/* ──────────────────────────────────────────────────────────────────────────
+   1.  Meteora DAAM → swaps
+   ────────────────────────────────────────────────────────────────────────── */
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_meteora_daam_swap
+TO swaps AS
+SELECT
+    block_num,
+    block_hash,
+    timestamp,
+
+    transaction_index,
+    instruction_index,
+
+    signature,
+    fee_payer,
+    signers_raw,
+    fee,
+    compute_units_consumed,
+
+    program_id,
+    stack_height,
+
+    payer AS user,
+    program_id AS amm,
+    pool AS amm_pool,
+    input_mint,
+    amount_in AS input_amount,
+    output_mint,
+    amount_out AS output_amount
+FROM meteora_daam_swap AS s
+WHERE input_amount > 1 AND output_amount > 1;
+
+/* ──────────────────────────────────────────────────────────────────────────
+   1.  Meteora AMM → swaps
+   ────────────────────────────────────────────────────────────────────────── */
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_meteora_amm_swap
+TO swaps AS
+SELECT
+    block_num,
+    block_hash,
+    timestamp,
+
+    transaction_index,
+    instruction_index,
+
+    signature,
+    fee_payer,
+    signers_raw,
+    fee,
+    compute_units_consumed,
+
+    program_id,
+    stack_height,
+
+    user,
+    program_id AS amm,
+    pool AS amm_pool,
+    input_mint,
+    amount_in AS input_amount,
+    output_mint,
+    amount_out AS output_amount
+FROM meteora_amm_swap AS s
+WHERE input_amount > 1 AND output_amount > 1;

--- a/clickhouse-solana-dex/src/lib.rs
+++ b/clickhouse-solana-dex/src/lib.rs
@@ -1,8 +1,14 @@
 mod enums;
 mod jupiter;
+mod meteora_amm;
+mod meteora_daam;
+mod meteora_dllm;
 mod pumpfun;
 mod pumpfun_amm;
 mod raydium_amm_v4;
+mod raydium_clmm;
+mod raydium_cpmm;
+mod raydium_launchpad;
 
 use common::clickhouse::set_clock;
 use proto::pb;
@@ -15,6 +21,12 @@ pub fn db_out(
     pumpfun_events: pb::pumpfun::v1::Events,
     pumpfun_amm_events: pb::pumpfun::amm::v1::Events,
     raydium_amm_v4_events: pb::raydium::amm::v1::Events,
+    raydium_cpmm_events: pb::raydium::cpmm::v1::Events,
+    raydium_clmm_events: pb::raydium::clmm::v1::Events,
+    raydium_launchpad_events: pb::raydium::launchpad::v1::Events,
+    meteora_dllm_events: pb::meteora::dllm::v1::Events,
+    meteora_daam_events: pb::meteora::daam::v1::Events,
+    meteora_amm_events: pb::meteora::amm::v1::Events,
     jupiter_v4_events: pb::jupiter::v1::Events,
     jupiter_v6_events: pb::jupiter::v1::Events,
 ) -> Result<DatabaseChanges, Error> {
@@ -24,6 +36,12 @@ pub fn db_out(
     pumpfun::process_events(&mut tables, &clock, &pumpfun_events);
     pumpfun_amm::process_events(&mut tables, &clock, &pumpfun_amm_events);
     raydium_amm_v4::process_events(&mut tables, &clock, &raydium_amm_v4_events);
+    raydium_cpmm::process_events(&mut tables, &clock, &raydium_cpmm_events);
+    raydium_clmm::process_events(&mut tables, &clock, &raydium_clmm_events);
+    raydium_launchpad::process_events(&mut tables, &clock, &raydium_launchpad_events);
+    meteora_dllm::process_events(&mut tables, &clock, &meteora_dllm_events);
+    meteora_daam::process_events(&mut tables, &clock, &meteora_daam_events);
+    meteora_amm::process_events(&mut tables, &clock, &meteora_amm_events);
     jupiter::process_events(&mut tables, &clock, &jupiter_v4_events);
     jupiter::process_events(&mut tables, &clock, &jupiter_v6_events);
 

--- a/clickhouse-solana-dex/src/meteora_amm.rs
+++ b/clickhouse-solana-dex/src/meteora_amm.rs
@@ -1,0 +1,62 @@
+use common::clickhouse::{common_key_v2, set_clock};
+use proto::pb::meteora::amm::v1 as pb;
+use substreams::pb::substreams::Clock;
+use substreams_database_change::tables::{Row, Tables};
+use substreams_solana::base58;
+
+pub fn process_events(tables: &mut Tables, clock: &Clock, events: &pb::Events) {
+    for (transaction_index, tx) in events.transactions.iter().enumerate() {
+        if tx.logs.len() != tx.instructions.len() {
+            continue;
+        }
+        for (instruction_index, ix) in tx.instructions.iter().enumerate() {
+            if let Some(pb::instruction::Instruction::Swap(data)) = &ix.instruction {
+                let log = match &tx.logs[instruction_index].log {
+                    Some(pb::log::Log::Swap(l)) => l,
+                    _ => continue,
+                };
+                handle_swap(tables, clock, tx, ix, data.accounts.as_ref(), log, transaction_index, instruction_index);
+            }
+        }
+    }
+}
+
+fn handle_swap(
+    tables: &mut Tables,
+    clock: &Clock,
+    tx: &pb::Transaction,
+    ix: &pb::Instruction,
+    accounts_opt: Option<&pb::SwapAccounts>,
+    log: &pb::SwapLog,
+    transaction_index: usize,
+    instruction_index: usize,
+) {
+    let accounts = match accounts_opt {
+        Some(a) => a,
+        None => return,
+    };
+    let key = common_key_v2(clock, transaction_index, instruction_index);
+    let row = tables
+        .create_row("meteora_amm_swap", key)
+        .set("user", base58::encode(&accounts.user))
+        .set("pool", base58::encode(&accounts.pool))
+        .set("input_mint", base58::encode(&accounts.user_source_token))
+        .set("output_mint", base58::encode(&accounts.user_destination_token))
+        .set("amount_in", log.in_amount)
+        .set("amount_out", log.out_amount);
+    set_instruction(ix, row);
+    set_transaction(tx, row);
+    set_clock(clock, row);
+}
+
+fn set_transaction(tx: &pb::Transaction, row: &mut Row) {
+    row.set("signature", base58::encode(&tx.signature))
+        .set("fee_payer", base58::encode(&tx.fee_payer))
+        .set("signers_raw", tx.signers.iter().map(base58::encode).collect::<Vec<_>>().join(","))
+        .set("fee", tx.fee)
+        .set("compute_units_consumed", tx.compute_units_consumed);
+}
+
+fn set_instruction(ix: &pb::Instruction, row: &mut Row) {
+    row.set("program_id", base58::encode(&ix.program_id)).set("stack_height", ix.stack_height);
+}

--- a/clickhouse-solana-dex/src/meteora_daam.rs
+++ b/clickhouse-solana-dex/src/meteora_daam.rs
@@ -1,0 +1,68 @@
+use common::clickhouse::{common_key_v2, set_clock};
+use proto::pb::meteora::daam::v1 as pb;
+use substreams::pb::substreams::Clock;
+use substreams_database_change::tables::{Row, Tables};
+use substreams_solana::base58;
+
+pub fn process_events(tables: &mut Tables, clock: &Clock, events: &pb::Events) {
+    for (transaction_index, tx) in events.transactions.iter().enumerate() {
+        if tx.logs.len() != tx.instructions.len() {
+            continue;
+        }
+        for (instruction_index, ix) in tx.instructions.iter().enumerate() {
+            if let Some(pb::instruction::Instruction::Swap(data)) = &ix.instruction {
+                let log = match &tx.logs[instruction_index].log {
+                    Some(pb::log::Log::Swap(l)) => l,
+                    _ => continue,
+                };
+                handle_swap(tables, clock, tx, ix, data.accounts.as_ref(), log, transaction_index, instruction_index);
+            }
+        }
+    }
+}
+
+fn handle_swap(
+    tables: &mut Tables,
+    clock: &Clock,
+    tx: &pb::Transaction,
+    ix: &pb::Instruction,
+    accounts_opt: Option<&pb::SwapAccounts>,
+    log: &pb::SwapLog,
+    transaction_index: usize,
+    instruction_index: usize,
+) {
+    let accounts = match accounts_opt {
+        Some(a) => a,
+        None => return,
+    };
+    let (input_mint, output_mint) = if log.trade_direction == 0 {
+        (&accounts.token_a_mint, &accounts.token_b_mint)
+    } else {
+        (&accounts.token_b_mint, &accounts.token_a_mint)
+    };
+    let output_amount = log.result.as_ref().map(|r| r.output_amount).unwrap_or_default();
+    let key = common_key_v2(clock, transaction_index, instruction_index);
+    let row = tables
+        .create_row("meteora_daam_swap", key)
+        .set("payer", base58::encode(&accounts.payer))
+        .set("pool", base58::encode(&accounts.pool))
+        .set("input_mint", base58::encode(input_mint))
+        .set("output_mint", base58::encode(output_mint))
+        .set("amount_in", log.actual_amount_in)
+        .set("amount_out", output_amount);
+    set_instruction(ix, row);
+    set_transaction(tx, row);
+    set_clock(clock, row);
+}
+
+fn set_transaction(tx: &pb::Transaction, row: &mut Row) {
+    row.set("signature", base58::encode(&tx.signature))
+        .set("fee_payer", base58::encode(&tx.fee_payer))
+        .set("signers_raw", tx.signers.iter().map(base58::encode).collect::<Vec<_>>().join(","))
+        .set("fee", tx.fee)
+        .set("compute_units_consumed", tx.compute_units_consumed);
+}
+
+fn set_instruction(ix: &pb::Instruction, row: &mut Row) {
+    row.set("program_id", base58::encode(&ix.program_id)).set("stack_height", ix.stack_height);
+}

--- a/clickhouse-solana-dex/src/meteora_dllm.rs
+++ b/clickhouse-solana-dex/src/meteora_dllm.rs
@@ -1,0 +1,71 @@
+use common::clickhouse::{common_key_v2, set_clock};
+use proto::pb::meteora::dllm::v1 as pb;
+use substreams::pb::substreams::Clock;
+use substreams_database_change::tables::{Row, Tables};
+use substreams_solana::base58;
+
+pub fn process_events(tables: &mut Tables, clock: &Clock, events: &pb::Events) {
+    for (transaction_index, tx) in events.transactions.iter().enumerate() {
+        for (instruction_index, ix) in tx.instructions.iter().enumerate() {
+            if let Some(pb::instruction::Instruction::SwapInstruction(data)) = &ix.instruction {
+                if let Some(event) = get_swap_event(tx, instruction_index) {
+                    handle_swap(tables, clock, tx, ix, data.accounts.as_ref(), event, transaction_index, instruction_index);
+                }
+            }
+        }
+    }
+}
+
+fn get_swap_event(tx: &pb::Transaction, instruction_index: usize) -> Option<&pb::SwapEvent> {
+    if instruction_index + 1 < tx.instructions.len() {
+        if let Some(pb::instruction::Instruction::SwapEvent(ev)) = &tx.instructions[instruction_index + 1].instruction {
+            return Some(ev);
+        }
+    }
+    None
+}
+
+fn handle_swap(
+    tables: &mut Tables,
+    clock: &Clock,
+    tx: &pb::Transaction,
+    ix: &pb::Instruction,
+    accounts_opt: Option<&pb::SwapAccounts>,
+    event: &pb::SwapEvent,
+    transaction_index: usize,
+    instruction_index: usize,
+) {
+    let accounts = match accounts_opt {
+        Some(a) => a,
+        None => return,
+    };
+    let (input_mint, output_mint) = if event.swap_for_y {
+        (&accounts.token_x_mint, &accounts.token_y_mint)
+    } else {
+        (&accounts.token_y_mint, &accounts.token_x_mint)
+    };
+    let key = common_key_v2(clock, transaction_index, instruction_index);
+    let row = tables
+        .create_row("meteora_dllm_swap", key)
+        .set("user", base58::encode(&accounts.user))
+        .set("lb_pair", base58::encode(&accounts.lb_pair))
+        .set("input_mint", base58::encode(input_mint))
+        .set("output_mint", base58::encode(output_mint))
+        .set("amount_in", event.amount_in)
+        .set("amount_out", event.amount_out);
+    set_instruction(ix, row);
+    set_transaction(tx, row);
+    set_clock(clock, row);
+}
+
+fn set_transaction(tx: &pb::Transaction, row: &mut Row) {
+    row.set("signature", base58::encode(&tx.signature))
+        .set("fee_payer", base58::encode(&tx.fee_payer))
+        .set("signers_raw", tx.signers.iter().map(base58::encode).collect::<Vec<_>>().join(","))
+        .set("fee", tx.fee)
+        .set("compute_units_consumed", tx.compute_units_consumed);
+}
+
+fn set_instruction(ix: &pb::Instruction, row: &mut Row) {
+    row.set("program_id", base58::encode(&ix.program_id)).set("stack_height", ix.stack_height);
+}

--- a/clickhouse-solana-dex/src/raydium_clmm.rs
+++ b/clickhouse-solana-dex/src/raydium_clmm.rs
@@ -1,0 +1,80 @@
+use common::clickhouse::{common_key_v2, set_clock};
+use proto::pb::raydium::clmm::v1 as pb;
+use substreams::pb::substreams::Clock;
+use substreams_database_change::tables::{Row, Tables};
+use substreams_solana::base58;
+
+pub fn process_events(tables: &mut Tables, clock: &Clock, events: &pb::Events) {
+    for (transaction_index, tx) in events.transactions.iter().enumerate() {
+        if tx.logs.len() != tx.instructions.len() {
+            continue;
+        }
+        for (instruction_index, ix) in tx.instructions.iter().enumerate() {
+            if let Some(pb::instruction::Instruction::Swap(data)) = &ix.instruction {
+                let log = match &tx.logs[instruction_index].log {
+                    Some(pb::log::Log::Swap(l)) => l,
+                    _ => continue,
+                };
+                handle_swap(tables, clock, tx, ix, data, log, transaction_index, instruction_index);
+            }
+        }
+    }
+}
+
+fn handle_swap(
+    tables: &mut Tables,
+    clock: &Clock,
+    tx: &pb::Transaction,
+    ix: &pb::Instruction,
+    data: &pb::SwapInstruction,
+    log: &pb::SwapLog,
+    transaction_index: usize,
+    instruction_index: usize,
+) {
+    let (payer, pool_state, input_mint, output_mint) = match &data.accounts {
+        Some(pb::swap_instruction::Accounts::V1Accounts(acc)) => (
+            base58::encode(&acc.payer),
+            base58::encode(&acc.pool_state),
+            base58::encode(&acc.input_vault),
+            base58::encode(&acc.output_vault),
+        ),
+        Some(pb::swap_instruction::Accounts::V2Accounts(acc)) => (
+            base58::encode(&acc.payer),
+            base58::encode(&acc.pool_state),
+            base58::encode(&acc.input_vault_mint),
+            base58::encode(&acc.output_vault_mint),
+        ),
+        None => return,
+    };
+
+    let (amount_in, amount_out) = if log.zero_for_one {
+        (log.amount_0, log.amount_1)
+    } else {
+        (log.amount_1, log.amount_0)
+    };
+
+    let key = common_key_v2(clock, transaction_index, instruction_index);
+    let row = tables
+        .create_row("raydium_clmm_swap", key)
+        .set("payer", payer)
+        .set("pool_state", pool_state)
+        .set("input_mint", input_mint)
+        .set("output_mint", output_mint)
+        .set("amount_in", amount_in)
+        .set("amount_out", amount_out);
+    set_instruction(ix, row);
+    set_transaction(tx, row);
+    set_clock(clock, row);
+}
+
+fn set_transaction(tx: &pb::Transaction, row: &mut Row) {
+    row.set("signature", base58::encode(&tx.signature))
+        .set("fee_payer", base58::encode(&tx.fee_payer))
+        .set("signers_raw", tx.signers.iter().map(base58::encode).collect::<Vec<_>>().join(","))
+        .set("fee", tx.fee)
+        .set("compute_units_consumed", tx.compute_units_consumed);
+}
+
+fn set_instruction(ix: &pb::Instruction, row: &mut Row) {
+    row.set("program_id", base58::encode(&ix.program_id)).set("stack_height", ix.stack_height);
+}

--- a/clickhouse-solana-dex/src/raydium_cpmm.rs
+++ b/clickhouse-solana-dex/src/raydium_cpmm.rs
@@ -1,0 +1,98 @@
+use common::clickhouse::{common_key_v2, set_clock};
+use proto::pb::raydium::cpmm::v1 as pb;
+use substreams::pb::substreams::Clock;
+use substreams_database_change::tables::Row;
+use substreams_database_change::tables::Tables;
+use substreams_solana::base58;
+
+pub fn process_events(tables: &mut Tables, clock: &Clock, events: &pb::Events) {
+    for (transaction_index, tx) in events.transactions.iter().enumerate() {
+        if tx.logs.len() != tx.instructions.len() {
+            continue;
+        }
+        for (instruction_index, ix) in tx.instructions.iter().enumerate() {
+            match &ix.instruction {
+                Some(pb::instruction::Instruction::SwapBaseInput(data)) => {
+                    let log = match &tx.logs[instruction_index].log {
+                        Some(pb::log::Log::Swap(l)) => l,
+                        _ => continue,
+                    };
+                    let accounts = match &data.accounts {
+                        Some(a) => a,
+                        None => continue,
+                    };
+                    handle_swap(
+                        tables,
+                        clock,
+                        tx,
+                        ix,
+                        accounts,
+                        log,
+                        "raydium_cpmm_swap_base_in",
+                        transaction_index,
+                        instruction_index,
+                    );
+                }
+                Some(pb::instruction::Instruction::SwapBaseOutput(data)) => {
+                    let log = match &tx.logs[instruction_index].log {
+                        Some(pb::log::Log::Swap(l)) => l,
+                        _ => continue,
+                    };
+                    let accounts = match &data.accounts {
+                        Some(a) => a,
+                        None => continue,
+                    };
+                    handle_swap(
+                        tables,
+                        clock,
+                        tx,
+                        ix,
+                        accounts,
+                        log,
+                        "raydium_cpmm_swap_base_out",
+                        transaction_index,
+                        instruction_index,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn handle_swap(
+    tables: &mut Tables,
+    clock: &Clock,
+    tx: &pb::Transaction,
+    ix: &pb::Instruction,
+    accounts: &pb::SwapAccounts,
+    log: &pb::SwapEvent,
+    table: &str,
+    transaction_index: usize,
+    instruction_index: usize,
+) {
+    let key = common_key_v2(clock, transaction_index, instruction_index);
+    let row = tables
+        .create_row(table, key)
+        .set("payer", base58::encode(&accounts.payer))
+        .set("pool_state", base58::encode(&accounts.pool_state))
+        .set("input_token_mint", base58::encode(&accounts.input_token_mint))
+        .set("output_token_mint", base58::encode(&accounts.output_token_mint))
+        .set("amount_in", log.input_amount)
+        .set("amount_out", log.output_amount);
+    set_instruction(ix, row);
+    set_transaction(tx, row);
+    set_clock(clock, row);
+}
+
+fn set_transaction(tx: &pb::Transaction, row: &mut Row) {
+    row.set("signature", base58::encode(&tx.signature))
+        .set("fee_payer", base58::encode(&tx.fee_payer))
+        .set("signers_raw", tx.signers.iter().map(base58::encode).collect::<Vec<_>>().join(","))
+        .set("fee", tx.fee)
+        .set("compute_units_consumed", tx.compute_units_consumed);
+}
+
+fn set_instruction(ix: &pb::Instruction, row: &mut Row) {
+    row.set("program_id", base58::encode(&ix.program_id)).set("stack_height", ix.stack_height);
+}

--- a/clickhouse-solana-dex/src/raydium_launchpad.rs
+++ b/clickhouse-solana-dex/src/raydium_launchpad.rs
@@ -1,0 +1,126 @@
+use common::clickhouse::{common_key_v2, set_clock};
+use proto::pb::raydium::launchpad::v1 as pb;
+use substreams::pb::substreams::Clock;
+use substreams_database_change::tables::{Row, Tables};
+use substreams_solana::base58;
+
+pub fn process_events(tables: &mut Tables, clock: &Clock, events: &pb::Events) {
+    for (transaction_index, tx) in events.transactions.iter().enumerate() {
+        for (instruction_index, ix) in tx.instructions.iter().enumerate() {
+            match &ix.instruction {
+                Some(pb::instruction::Instruction::BuyExactIn(data)) => {
+                    if let Some(event) = get_trade_event(tx, instruction_index) {
+                        handle_trade(
+                            tables,
+                            clock,
+                            tx,
+                            ix,
+                            data.accounts.as_ref(),
+                            event,
+                            "raydium_launchpad_buy",
+                            transaction_index,
+                            instruction_index,
+                        );
+                    }
+                }
+                Some(pb::instruction::Instruction::BuyExactOut(data)) => {
+                    if let Some(event) = get_trade_event(tx, instruction_index) {
+                        handle_trade(
+                            tables,
+                            clock,
+                            tx,
+                            ix,
+                            data.accounts.as_ref(),
+                            event,
+                            "raydium_launchpad_buy",
+                            transaction_index,
+                            instruction_index,
+                        );
+                    }
+                }
+                Some(pb::instruction::Instruction::SellExactIn(data)) => {
+                    if let Some(event) = get_trade_event(tx, instruction_index) {
+                        handle_trade(
+                            tables,
+                            clock,
+                            tx,
+                            ix,
+                            data.accounts.as_ref(),
+                            event,
+                            "raydium_launchpad_sell",
+                            transaction_index,
+                            instruction_index,
+                        );
+                    }
+                }
+                Some(pb::instruction::Instruction::SellExactOut(data)) => {
+                    if let Some(event) = get_trade_event(tx, instruction_index) {
+                        handle_trade(
+                            tables,
+                            clock,
+                            tx,
+                            ix,
+                            data.accounts.as_ref(),
+                            event,
+                            "raydium_launchpad_sell",
+                            transaction_index,
+                            instruction_index,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn get_trade_event(tx: &pb::Transaction, instruction_index: usize) -> Option<&pb::TradeEvent> {
+    if instruction_index + 1 < tx.instructions.len() {
+        if let Some(pb::instruction::Instruction::TradeEvent(ev)) = &tx.instructions[instruction_index + 1].instruction {
+            return Some(ev);
+        }
+    }
+    None
+}
+
+fn handle_trade(
+    tables: &mut Tables,
+    clock: &Clock,
+    tx: &pb::Transaction,
+    ix: &pb::Instruction,
+    accounts_opt: Option<&pb::TradeAccounts>,
+    event: &pb::TradeEvent,
+    table: &str,
+    transaction_index: usize,
+    instruction_index: usize,
+) {
+    let accounts = match accounts_opt {
+        Some(a) => a,
+        None => return,
+    };
+    let key = common_key_v2(clock, transaction_index, instruction_index);
+    let row = tables
+        .create_row(table, key)
+        .set("payer", base58::encode(&accounts.payer))
+        .set("pool_state", base58::encode(&accounts.pool_state))
+        .set("base_token_mint", base58::encode(&accounts.base_token_mint))
+        .set("quote_token_mint", base58::encode(&accounts.quote_token_mint))
+        .set("amount_in", event.amount_in)
+        .set("amount_out", event.amount_out)
+        .set("exact_in", event.exact_in);
+    set_instruction(ix, row);
+    set_transaction(tx, row);
+    set_clock(clock, row);
+}
+
+fn set_transaction(tx: &pb::Transaction, row: &mut Row) {
+    row.set("signature", base58::encode(&tx.signature))
+        .set("fee_payer", base58::encode(&tx.fee_payer))
+        .set("signers_raw", tx.signers.iter().map(base58::encode).collect::<Vec<_>>().join(","))
+        .set("fee", tx.fee)
+        .set("compute_units_consumed", tx.compute_units_consumed);
+}
+
+fn set_instruction(ix: &pb::Instruction, row: &mut Row) {
+    row.set("program_id", base58::encode(&ix.program_id)).set("stack_height", ix.stack_height);
+}

--- a/clickhouse-solana-dex/substreams.yaml
+++ b/clickhouse-solana-dex/substreams.yaml
@@ -15,6 +15,12 @@ imports:
   pumpfun: https://github.com/pinax-network/substreams-solana/releases/download/pumpfun-v0.2.1/pumpfun-v0.2.1.spkg
   pumpfun_amm: https://github.com/pinax-network/substreams-solana/releases/download/solana-dex-v0.2.0/pumpfun-amm-v0.2.0.spkg
   raydium_amm_v4: https://github.com/pinax-network/substreams-solana/releases/download/solana-dex-v0.2.0/raydium-amm-v4-v0.2.0.spkg
+  raydium_cpmm: https://github.com/pinax-network/substreams-solana/releases/download/solana-dex-v0.2.0/raydium-cpmm-v0.2.0.spkg
+  raydium_clmm: https://github.com/pinax-network/substreams-solana/releases/download/solana-dex-v0.2.0/raydium-clmm-v0.2.0.spkg
+  raydium_launchpad: https://github.com/pinax-network/substreams-solana/releases/download/solana-dex-v0.2.0/raydium-launchpad-v0.2.0.spkg
+  meteora_dllm: https://github.com/pinax-network/substreams-solana/releases/download/solana-dex-v0.2.0/meteora-dllm-v0.2.0.spkg
+  meteora_daam: https://github.com/pinax-network/substreams-solana/releases/download/solana-dex-v0.2.0/meteora-daam-v0.2.0.spkg
+  meteora_amm: https://github.com/pinax-network/substreams-solana/releases/download/solana-dex-v0.2.0/meteora-amm-v0.2.0.spkg
   jupiter_v4: https://github.com/pinax-network/substreams-solana/releases/download/solana-dex-v0.2.0/jupiter-v4-v0.2.0.spkg
   jupiter_v6: https://github.com/pinax-network/substreams-solana/releases/download/solana-dex-v0.2.0/jupiter-v6-v0.2.0.spkg
 
@@ -33,6 +39,12 @@ modules:
       - map: pumpfun:map_events
       - map: pumpfun_amm:map_events
       - map: raydium_amm_v4:map_events
+      - map: raydium_cpmm:map_events
+      - map: raydium_clmm:map_events
+      - map: raydium_launchpad:map_events
+      - map: meteora_dllm:map_events
+      - map: meteora_daam:map_events
+      - map: meteora_amm:map_events
       - map: jupiter_v4:map_events
       - map: jupiter_v6:map_events
 


### PR DESCRIPTION
## Summary
- integrate Raydium CPMM, CLMM & Launchpad swap handlers
- add Meteora DLLM, DAAM & AMM swap handlers
- expand swaps view and schemas for new DEXs

## Testing
- `cargo test -p clickhouse-solana-dex`


------
https://chatgpt.com/codex/tasks/task_b_68c5b4898e70832890b9c9c44e630238