### PR TITLE
Fix/set authority

### DIFF
--- a/clickhouse-solana-tokens/Makefile
+++ b/clickhouse-solana-tokens/Makefile
@@ -1,6 +1,6 @@
 ENDPOINT ?= solana.substreams.pinax.network:443
 START_BLOCK ?= 350000000
-STOP_BLOCK ?= 350010000
+STOP_BLOCK ?= 350001000
 PARALLEL_JOBS ?= 500
 
 .PHONY: build

--- a/clickhouse-solana-tokens/Makefile
+++ b/clickhouse-solana-tokens/Makefile
@@ -1,6 +1,6 @@
 ENDPOINT ?= solana.substreams.pinax.network:443
 START_BLOCK ?= 350000000
-STOP_BLOCK ?= 350001000
+STOP_BLOCK ?= 350002000
 PARALLEL_JOBS ?= 500
 
 .PHONY: build

--- a/clickhouse-solana-tokens/schema.2.mv.accounts.sql
+++ b/clickhouse-solana-tokens/schema.2.mv.accounts.sql
@@ -27,21 +27,21 @@ ALTER TABLE owner_state_latest
     ADD PROJECTION IF NOT EXISTS prj_owner (SELECT * ORDER BY owner);
 
 -- MINT
-CREATE TABLE IF NOT EXISTS mint_state_latest AS TEMPLATE_ACCOUNTS_STATE;
-ALTER TABLE mint_state_latest
+CREATE TABLE IF NOT EXISTS account_mint_state_latest AS TEMPLATE_ACCOUNTS_STATE;
+ALTER TABLE account_mint_state_latest
     ADD COLUMN IF NOT EXISTS mint LowCardinality(String),
     MODIFY COLUMN is_deleted UInt8 MATERIALIZED if(mint = '', 1, 0),
     ADD PROJECTION IF NOT EXISTS prj_mint (SELECT * ORDER BY (mint, account));
 
--- CLOSED (0/1)
-CREATE TABLE IF NOT EXISTS closed_state_latest AS TEMPLATE_ACCOUNTS_STATE;
-ALTER TABLE closed_state_latest
+-- CLOSE ACCOUNT (0/1)
+CREATE TABLE IF NOT EXISTS close_account_state_latest AS TEMPLATE_ACCOUNTS_STATE;
+ALTER TABLE close_account_state_latest
     ADD COLUMN IF NOT EXISTS closed UInt8,
     MODIFY COLUMN is_deleted UInt8 MATERIALIZED if(closed = 0, 1, 0);
 
 -- FROZEN (0/1)
-CREATE TABLE IF NOT EXISTS frozen_state_latest AS TEMPLATE_ACCOUNTS_STATE;
-ALTER TABLE frozen_state_latest
+CREATE TABLE IF NOT EXISTS freeze_account_state_latest AS TEMPLATE_ACCOUNTS_STATE;
+ALTER TABLE freeze_account_state_latest
     ADD COLUMN IF NOT EXISTS frozen UInt8,
     MODIFY COLUMN is_deleted UInt8 MATERIALIZED if(frozen = 0, 1, 0);
 
@@ -63,7 +63,7 @@ SELECT
 FROM initialize_account;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_mint_state_initialize_mint
-TO mint_state_latest AS
+TO account_mint_state_latest AS
 SELECT
   account,
   mint,
@@ -72,8 +72,8 @@ SELECT
   timestamp
 FROM initialize_account;
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mv_closed_state_initialize_closed0
-TO closed_state_latest AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_close_account_state_initialize_closed0
+TO close_account_state_latest AS
 SELECT
   account,
   0 as closed,
@@ -82,8 +82,8 @@ SELECT
   timestamp
 FROM initialize_account;
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mv_frozen_state_initialize_frozen0
-TO frozen_state_latest AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_freeze_account_state_initialize_frozen0
+TO freeze_account_state_latest AS
 SELECT
   account,
   0 as frozen,
@@ -93,8 +93,8 @@ SELECT
 FROM initialize_account;
 
 -- CLOSE -> closed = 1 (do not touch others)
-CREATE MATERIALIZED VIEW IF NOT EXISTS mv_closed_state_close_account
-TO closed_state_latest AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_close_account_state_close_account
+TO close_account_state_latest AS
 SELECT
   account,
   1 as closed,
@@ -103,7 +103,7 @@ SELECT
   timestamp
 FROM close_account;
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mv_closed_state_close_account_owner
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_close_account_state_close_account_owner
 TO owner_state_latest AS
 SELECT
   account,
@@ -113,8 +113,8 @@ SELECT
   timestamp
 FROM close_account;
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mv_closed_state_close_account_mint
-TO mint_state_latest AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_close_account_state_close_account_mint
+TO account_mint_state_latest AS
 SELECT
   account,
   '' as mint,
@@ -136,8 +136,8 @@ FROM set_authority
 WHERE authority_type = 'AccountOwner';
 
 -- FREEZE / THAW
-CREATE MATERIALIZED VIEW IF NOT EXISTS mv_frozen_state_freeze_account
-TO frozen_state_latest AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_freeze_account_state_freeze_account
+TO freeze_account_state_latest AS
 SELECT
   account,
   1 as frozen,
@@ -146,8 +146,8 @@ SELECT
   timestamp
 FROM freeze_account;
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mv_frozen_state_thaw_account
-TO frozen_state_latest AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_freeze_account_state_thaw_account
+TO freeze_account_state_latest AS
 SELECT
   account,
   0 as frozen,

--- a/clickhouse-solana-tokens/schema.2.mv.metadata.sql
+++ b/clickhouse-solana-tokens/schema.2.mv.metadata.sql
@@ -34,7 +34,6 @@ ALTER TABLE metadata_symbol_state_latest
     ADD COLUMN IF NOT EXISTS symbol LowCardinality(String) AFTER metadata,
     ADD PROJECTION IF NOT EXISTS prj_symbol (SELECT * ORDER BY (symbol, metadata));
 
-
 /* URI */
 CREATE TABLE IF NOT EXISTS metadata_uri_state_latest AS TEMPLATE_METADATA;
 ALTER TABLE metadata_uri_state_latest

--- a/clickhouse-solana-tokens/schema.2.mv.mints.sql
+++ b/clickhouse-solana-tokens/schema.2.mv.mints.sql
@@ -1,37 +1,72 @@
-CREATE TABLE IF NOT EXISTS mints (
-    -- block --
-    block_num           UInt32,
-    timestamp           DateTime(0, 'UTC'),
-    version             UInt64,
-
-    -- mint --
-    mint              LowCardinality(String),
-    mint_authority    String,
-    freeze_authority  Nullable(String),
-    decimals          UInt8,
+CREATE TABLE IF NOT EXISTS TEMPLATE_MINTS_STATE (
+    mint         String,
+    version      UInt64,
+    is_deleted   UInt8,
+    block_num    UInt32,
+    timestamp    DateTime(0, 'UTC'),
 
     -- indexes --
-    INDEX idx_mint_authority (mint_authority) TYPE bloom_filter(0.005) GRANULARITY 1,
-    INDEX idx_freeze_authority (freeze_authority) TYPE bloom_filter(0.005) GRANULARITY 1,
-    INDEX idx_decimals (decimals) TYPE minmax GRANULARITY 1
+    INDEX idx_block_num (block_num) TYPE minmax GRANULARITY 1,
+    INDEX idx_timestamp (timestamp) TYPE minmax GRANULARITY 1,
+    INDEX idx_is_deleted (is_deleted) TYPE set(2) GRANULARITY 1
+)
+ENGINE = ReplacingMergeTree(version, is_deleted)
+ORDER BY (mint);
 
-) ENGINE = ReplacingMergeTree(version)
-ORDER BY mint
-COMMENT 'SPL Token Mints';
+-- TTL to clean up deleted rows after 0 seconds (immediate cleanup on merge)
+ALTER TABLE TEMPLATE_MINTS_STATE
+  MODIFY SETTING allow_experimental_replacing_merge_with_cleanup = 1;
+ALTER TABLE TEMPLATE_MINTS_STATE
+  MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';
 
-ALTER TABLE mints MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';
-ALTER TABLE mints
-    ADD PROJECTION IF NOT EXISTS prj_mint_authority (SELECT * ORDER BY mint_authority),
-    ADD PROJECTION IF NOT EXISTS prj_freeze_authority (SELECT * ORDER BY freeze_authority);
+-- DECIMALS
+CREATE TABLE IF NOT EXISTS decimals_state_latest AS TEMPLATE_MINTS_STATE;
+ALTER TABLE decimals_state_latest
+    ADD COLUMN IF NOT EXISTS decimals UInt8,
+    ADD INDEX IF NOT EXISTS idx_decimals (decimals) TYPE minmax GRANULARITY 1;
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mv_mints_initialize_mint
-TO mints AS
+-- MINT AUTHORITY
+CREATE TABLE IF NOT EXISTS mint_authority_state_latest AS TEMPLATE_MINTS_STATE;
+ALTER TABLE mint_authority_state_latest
+    ADD COLUMN IF NOT EXISTS mint_authority String,
+    MODIFY COLUMN is_deleted UInt8 MATERIALIZED if(mint_authority = '', 1, 0),
+    ADD PROJECTION IF NOT EXISTS prj_mint_authority (SELECT * ORDER BY (mint_authority, mint));
+
+-- FREEZE AUTHORITY
+CREATE TABLE IF NOT EXISTS freeze_authority_state_latest AS TEMPLATE_MINTS_STATE;
+ALTER TABLE freeze_authority_state_latest
+    ADD COLUMN IF NOT EXISTS freeze_authority String,
+    MODIFY COLUMN is_deleted UInt8 MATERIALIZED if(freeze_authority = '', 1, 0),
+    ADD PROJECTION IF NOT EXISTS prj_freeze_authority (SELECT * ORDER BY (freeze_authority, mint));
+
+-- INITIALIZE
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_decimals_state_initialize_mint
+TO decimals_state_latest AS
 SELECT
-    block_num,
-    timestamp,
-    version,
-    mint,
-    mint_authority,
-    freeze_authority,
-    decimals
+  mint,
+  decimals,
+  version,
+  block_num,
+  timestamp
 FROM initialize_mint;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_mint_authority_state_initialize_mint
+TO mint_authority_state_latest AS
+SELECT
+  mint,
+  mint_authority,
+  version,
+  block_num,
+  timestamp
+FROM initialize_mint;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_freeze_authority_state_initialize_mint
+TO freeze_authority_state_latest AS
+SELECT
+  mint,
+  freeze_authority,
+  version,
+  block_num,
+  timestamp
+FROM initialize_mint;
+

--- a/clickhouse-solana-tokens/schema.2.mv.mints.sql
+++ b/clickhouse-solana-tokens/schema.2.mv.mints.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS TEMPLATE_MINTS_STATE (
     mint         String,
+    program_id   LowCardinality(String),
     version      UInt64,
     is_deleted   UInt8,
     block_num    UInt32,
@@ -8,6 +9,7 @@ CREATE TABLE IF NOT EXISTS TEMPLATE_MINTS_STATE (
     -- indexes --
     INDEX idx_block_num (block_num) TYPE minmax GRANULARITY 1,
     INDEX idx_timestamp (timestamp) TYPE minmax GRANULARITY 1,
+    INDEX idx_program_id (program_id) TYPE set(2) GRANULARITY 1,
     INDEX idx_is_deleted (is_deleted) TYPE set(2) GRANULARITY 1
 )
 ENGINE = ReplacingMergeTree(version, is_deleted)
@@ -49,6 +51,7 @@ ALTER TABLE close_mint_state_latest
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_decimals_state_initialize_mint
 TO decimals_state_latest AS
 SELECT
+  program_id,
   mint,
   decimals,
   version,
@@ -59,6 +62,7 @@ FROM initialize_mint;
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_mint_authority_state_initialize_mint
 TO mint_authority_state_latest AS
 SELECT
+  program_id,
   mint,
   mint_authority,
   version,
@@ -69,6 +73,7 @@ FROM initialize_mint;
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_freeze_authority_state_initialize_mint
 TO freeze_authority_state_latest AS
 SELECT
+  program_id,
   mint,
   freeze_authority_raw AS freeze_authority,
   version,
@@ -79,6 +84,7 @@ FROM initialize_mint;
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_close_mint_state_initialize_closed0
 TO close_mint_state_latest AS
 SELECT
+  program_id,
   mint,
   0 as closed,
   version,

--- a/clickhouse-solana-tokens/schema.2.mv.mints.sql
+++ b/clickhouse-solana-tokens/schema.2.mv.mints.sql
@@ -39,6 +39,12 @@ ALTER TABLE freeze_authority_state_latest
     MODIFY COLUMN is_deleted UInt8 MATERIALIZED if(freeze_authority = '', 1, 0),
     ADD PROJECTION IF NOT EXISTS prj_freeze_authority (SELECT * ORDER BY (freeze_authority, mint));
 
+-- CLOSED MINT (0/1)
+CREATE TABLE IF NOT EXISTS close_mint_state_latest AS TEMPLATE_MINTS_STATE;
+ALTER TABLE close_mint_state_latest
+    ADD COLUMN IF NOT EXISTS closed UInt8,
+    MODIFY COLUMN is_deleted UInt8 MATERIALIZED if(closed = 0, 1, 0);
+
 -- INITIALIZE
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_decimals_state_initialize_mint
 TO decimals_state_latest AS
@@ -70,3 +76,12 @@ SELECT
   timestamp
 FROM initialize_mint;
 
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_close_mint_state_initialize_closed0
+TO close_mint_state_latest AS
+SELECT
+  mint,
+  0 as closed,
+  version,
+  block_num,
+  timestamp
+FROM initialize_mint;

--- a/clickhouse-solana-tokens/schema.2.mv.mints.sql
+++ b/clickhouse-solana-tokens/schema.2.mv.mints.sql
@@ -70,7 +70,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS mv_freeze_authority_state_initialize_mint
 TO freeze_authority_state_latest AS
 SELECT
   mint,
-  freeze_authority,
+  freeze_authority_raw AS freeze_authority,
   version,
   block_num,
   timestamp

--- a/clickhouse-solana-tokens/schema.3.mv.set_authority.sql
+++ b/clickhouse-solana-tokens/schema.3.mv.set_authority.sql
@@ -19,6 +19,7 @@ ALTER TABLE set_authority
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_set_authority_freeze_authority
 TO freeze_authority_state_latest AS
 SELECT
+  program_id,
   account AS mint,
   new_authority_raw AS freeze_authority,
   version,
@@ -31,6 +32,7 @@ WHERE authority_type = 'AUTHORITY_TYPE_FREEZE_ACCOUNT';
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_set_authority_mint_authority
 TO mint_authority_state_latest AS
 SELECT
+  program_id,
   account AS mint,
   new_authority_raw AS mint_authority,
   version,
@@ -43,6 +45,7 @@ WHERE authority_type = 'AUTHORITY_TYPE_MINT_TOKENS';
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_set_authority_owner
 TO owner_state_latest AS
 SELECT
+  program_id,
   account,
   new_authority_raw AS owner,
   version,
@@ -55,6 +58,7 @@ WHERE authority_type = 'AUTHORITY_TYPE_ACCOUNT_OWNER';
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_closed_state_set_authority_owner
 TO owner_state_latest AS
 SELECT
+  program_id,
   account,
   '' as owner,
   version,
@@ -67,6 +71,7 @@ WHERE authority_type = 'AUTHORITY_TYPE_CLOSE_ACCOUNT';
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_close_mint_state_set_authority_close_mint
 TO close_mint_state_latest AS
 SELECT
+  program_id,
   account AS mint,
   1 AS closed,
   version,

--- a/clickhouse-solana-tokens/schema.3.mv.set_authority.sql
+++ b/clickhouse-solana-tokens/schema.3.mv.set_authority.sql
@@ -1,0 +1,92 @@
+-- SetAuthority --
+CREATE TABLE IF NOT EXISTS set_authority AS base_events
+COMMENT 'SPL Token SetAuthority events';
+ALTER TABLE set_authority
+    ADD COLUMN IF NOT EXISTS account                 String,
+    ADD COLUMN IF NOT EXISTS authority_type          LowCardinality(String), -- AuthorityType enum as string
+    ADD COLUMN IF NOT EXISTS new_authority_raw       String,
+    ADD COLUMN IF NOT EXISTS new_authority           Nullable(String) MATERIALIZED string_or_null(new_authority_raw),
+    ADD COLUMN IF NOT EXISTS authority               String,
+    ADD COLUMN IF NOT EXISTS multisig_authority_raw  String,
+    ADD COLUMN IF NOT EXISTS multisig_authority      Array(String) MATERIALIZED string_to_array(multisig_authority_raw),
+
+    -- Indexes --
+    ADD INDEX IF NOT EXISTS idx_account (account) TYPE bloom_filter(0.005) GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_new_authority (new_authority) TYPE bloom_filter(0.005) GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_authority (authority) TYPE bloom_filter(0.005) GRANULARITY 1;
+
+-- FREEZE AUTHORITY
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_set_authority_freeze_authority
+TO freeze_authority_state_latest AS
+SELECT
+  account AS mint,
+  new_authority AS freeze_authority,
+  version,
+  block_num,
+  timestamp
+FROM set_authority
+WHERE authority_type = 'AUTHORITY_TYPE_FREEZE_ACCOUNT';
+
+-- MINT AUTHORITY
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_set_authority_mint_authority
+TO mint_authority_state_latest AS
+SELECT
+  account AS mint,
+  new_authority AS mint_authority,
+  version,
+  block_num,
+  timestamp
+FROM set_authority
+WHERE authority_type = 'AUTHORITY_TYPE_MINT_TOKENS';
+
+-- OWNER (UPDATE AUTHORITY)
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_set_authority_owner
+TO owner_state_latest AS
+SELECT
+  account,
+  new_authority as owner,
+  version,
+  block_num,
+  timestamp
+FROM set_authority
+WHERE authority_type = 'AUTHORITY_TYPE_ACCOUNT_OWNER';
+
+-- CLOSE ACCOUNT
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_closed_state_set_authority_owner
+TO owner_state_latest AS
+SELECT
+  account,
+  '' as owner,
+  version,
+  block_num,
+  timestamp
+FROM set_authority
+WHERE authority_type = 'AUTHORITY_TYPE_CLOSE_ACCOUNT';
+
+-- CLOSE MINT
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_close_mint_state_set_authority_close_mint
+TO close_mint_state_latest AS
+SELECT
+  account AS mint,
+  1 AS closed,
+  version,
+  block_num,
+  timestamp
+FROM set_authority
+WHERE authority_type = 'AUTHORITY_TYPE_CLOSE_MINT';
+
+--     ┌─authority_type──────────────────────────────────┬───count()─┐
+--  1. │ AUTHORITY_TYPE_ACCOUNT_OWNER                    │ 123645372 │
+--  2. │ AUTHORITY_TYPE_CLOSE_ACCOUNT                    │ 110497166 │
+--  3. │ AUTHORITY_TYPE_MINT_TOKENS                      │  66885099 │
+--  4. │ AUTHORITY_TYPE_FREEZE_ACCOUNT                   │  41076484 │
+--  5. │ AUTHORITY_TYPE_METADATA_POINTER                 │     32059 │
+--  6. │ AUTHORITY_TYPE_PERMANENT_DELEGATE               │     15154 │
+--  7. │ AUTHORITY_TYPE_CLOSE_MINT                       │     14368 │
+--  8. │ AUTHORITY_TYPE_TRANSFER_FEE_CONFIG              │      8904 │
+--  9. │ AUTHORITY_TYPE_WITHHELD_WITHDRAW                │      2800 │
+-- 10. │ AUTHORITY_TYPE_TRANSFER_HOOK_PROGRAM_ID         │       186 │
+-- 11. │ AUTHORITY_TYPE_CONFIDENTIAL_TRANSFER_MINT       │        67 │
+-- 12. │ AUTHORITY_TYPE_CONFIDENTIAL_TRANSFER_FEE_CONFIG │        12 │
+-- 13. │ AUTHORITY_TYPE_INTEREST_RATE                    │         9 │
+--     └─────────────────────────────────────────────────┴───────────┘

--- a/clickhouse-solana-tokens/schema.3.mv.set_authority.sql
+++ b/clickhouse-solana-tokens/schema.3.mv.set_authority.sql
@@ -20,7 +20,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS mv_set_authority_freeze_authority
 TO freeze_authority_state_latest AS
 SELECT
   account AS mint,
-  new_authority AS freeze_authority,
+  new_authority_raw AS freeze_authority,
   version,
   block_num,
   timestamp
@@ -32,7 +32,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS mv_set_authority_mint_authority
 TO mint_authority_state_latest AS
 SELECT
   account AS mint,
-  new_authority AS mint_authority,
+  new_authority_raw AS mint_authority,
   version,
   block_num,
   timestamp
@@ -44,7 +44,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS mv_set_authority_owner
 TO owner_state_latest AS
 SELECT
   account,
-  new_authority as owner,
+  new_authority_raw AS owner,
   version,
   block_num,
   timestamp

--- a/clickhouse-solana-tokens/schema.3.view.accounts.sql
+++ b/clickhouse-solana-tokens/schema.3.view.accounts.sql
@@ -40,8 +40,18 @@ SELECT
 FROM frozen_state_latest AS a
 GROUP BY account;
 
+CREATE OR REPLACE VIEW accounts_immutable_view AS
+SELECT
+  account,
+  max(version)   AS version,
+  max(block_num) AS block_num,
+  max(timestamp) AS timestamp,
+  argMax(a.immutable, a.version) AS immutable
+FROM immutable_owner_state_latest AS a
+GROUP BY account;
+
 /* COMBINED VIEW — owner is required, others are optional */
-CREATE OR REPLACE VIEW accounts_view AS
+CREATE OR REPLACE VIEW accounts AS
 SELECT
   m.account as account,
   m.block_num as block_num,                 -- authoritative block_num from owner
@@ -49,8 +59,10 @@ SELECT
   if(empty(o.owner), NULL, o.owner) AS owner, -- can be null (belongs to system contract)
   if(empty(m.mint), NULL, m.mint) AS mint,
   c.closed AS closed,
-  f.frozen AS frozen
+  f.frozen AS frozen,
+  i.immutable AS immutable
 FROM accounts_mint_view AS m
 LEFT JOIN accounts_owner_view AS o USING (account)
 LEFT JOIN accounts_closed_view AS c USING (account)
-LEFT JOIN accounts_frozen_view AS f USING (account);
+LEFT JOIN accounts_frozen_view AS f USING (account)
+LEFT JOIN accounts_immutable_view AS i USING (account);

--- a/clickhouse-solana-tokens/schema.3.view.accounts.sql
+++ b/clickhouse-solana-tokens/schema.3.view.accounts.sql
@@ -1,5 +1,5 @@
 /* OWNER (spine) */
-CREATE OR REPLACE VIEW accounts_owner_view AS
+CREATE OR REPLACE VIEW owner_view AS
 SELECT
   account,
   max(version)   AS version,
@@ -10,37 +10,37 @@ FROM owner_state_latest AS a
 GROUP BY account;
 
 /* Optional fields kept as separate views (same pattern) */
-CREATE OR REPLACE VIEW accounts_mint_view AS
+CREATE OR REPLACE VIEW account_mint_view AS
 SELECT
   account,
   max(version)   AS version,
   max(block_num) AS block_num,
   max(timestamp) AS timestamp,
   argMax(a.mint, a.version) AS mint
-FROM mint_state_latest AS a
+FROM account_mint_state_latest AS a
 GROUP BY account;
 
-CREATE OR REPLACE VIEW accounts_closed_view AS
+CREATE OR REPLACE VIEW close_account_view AS
 SELECT
   account,
   max(version)   AS version,
   max(block_num) AS block_num,
   max(timestamp) AS timestamp,
   argMax(a.closed, a.version) AS closed
-FROM closed_state_latest AS a
+FROM close_account_state_latest AS a
 GROUP BY account;
 
-CREATE OR REPLACE VIEW accounts_frozen_view AS
+CREATE OR REPLACE VIEW freeze_account_view AS
 SELECT
   account,
   max(version)   AS version,
   max(block_num) AS block_num,
   max(timestamp) AS timestamp,
   argMax(a.frozen, a.version) AS frozen
-FROM frozen_state_latest AS a
+FROM freeze_account_state_latest AS a
 GROUP BY account;
 
-CREATE OR REPLACE VIEW accounts_immutable_view AS
+CREATE OR REPLACE VIEW immutable_owner_view AS
 SELECT
   account,
   max(version)   AS version,
@@ -61,8 +61,8 @@ SELECT
   c.closed AS closed,
   f.frozen AS frozen,
   i.immutable AS immutable
-FROM accounts_mint_view AS m
-LEFT JOIN accounts_owner_view AS o USING (account)
-LEFT JOIN accounts_closed_view AS c USING (account)
-LEFT JOIN accounts_frozen_view AS f USING (account)
-LEFT JOIN accounts_immutable_view AS i USING (account);
+FROM account_mint_view AS m
+LEFT JOIN owner_view AS o USING (account)
+LEFT JOIN close_account_view AS c USING (account)
+LEFT JOIN freeze_account_view AS f USING (account)
+LEFT JOIN immutable_owner_view AS i USING (account);

--- a/clickhouse-solana-tokens/schema.3.view.accounts.sql
+++ b/clickhouse-solana-tokens/schema.3.view.accounts.sql
@@ -2,6 +2,7 @@
 CREATE OR REPLACE VIEW owner_view AS
 SELECT
   account,
+  any(program_id) AS program_id,
   max(version)   AS version,
   max(block_num) AS block_num,
   max(timestamp) AS timestamp,
@@ -13,6 +14,7 @@ GROUP BY account;
 CREATE OR REPLACE VIEW account_mint_view AS
 SELECT
   account,
+  any(program_id) AS program_id,
   max(version)   AS version,
   max(block_num) AS block_num,
   max(timestamp) AS timestamp,
@@ -23,6 +25,7 @@ GROUP BY account;
 CREATE OR REPLACE VIEW close_account_view AS
 SELECT
   account,
+  any(program_id) AS program_id,
   max(version)   AS version,
   max(block_num) AS block_num,
   max(timestamp) AS timestamp,
@@ -33,6 +36,7 @@ GROUP BY account;
 CREATE OR REPLACE VIEW freeze_account_view AS
 SELECT
   account,
+  any(program_id) AS program_id,
   max(version)   AS version,
   max(block_num) AS block_num,
   max(timestamp) AS timestamp,
@@ -43,6 +47,7 @@ GROUP BY account;
 CREATE OR REPLACE VIEW immutable_owner_view AS
 SELECT
   account,
+  any(program_id) AS program_id,
   max(version)   AS version,
   max(block_num) AS block_num,
   max(timestamp) AS timestamp,
@@ -50,12 +55,50 @@ SELECT
 FROM immutable_owner_state_latest AS a
 GROUP BY account;
 
-/* COMBINED VIEW — owner is required, others are optional */
-CREATE OR REPLACE VIEW accounts AS
+-- Ideal for general account lookups
+CREATE OR REPLACE VIEW accounts_view AS
 SELECT
-  m.account as account,
-  m.block_num as block_num,                 -- authoritative block_num from owner
-  m.timestamp as timestamp,                 -- authoritative timestamp from owner
+  a.account AS account,
+  a.program_id AS program_id,
+  a.block_num AS created_at_block_num,
+  a.timestamp AS created_at_timestamp,
+  if(empty(o.owner), NULL, o.owner) AS owner, -- can be null (belongs to system contract)
+  if(empty(m.mint), NULL, m.mint) AS mint,
+  c.closed AS closed,
+  f.frozen AS frozen,
+  i.immutable AS immutable
+FROM account_state_latest AS a
+LEFT JOIN account_mint_view AS m USING (account)
+LEFT JOIN owner_view AS o USING (account)
+LEFT JOIN close_account_view AS c USING (account)
+LEFT JOIN freeze_account_view AS f USING (account)
+LEFT JOIN immutable_owner_view AS i USING (account);
+
+-- Ideal for owner lookups (get all accounts of an owner)
+CREATE OR REPLACE VIEW accounts_from_owner_view AS
+SELECT
+  o.account AS account,
+  o.program_id AS program_id,
+  o.block_num AS created_at_block_num,
+  o.timestamp AS created_at_timestamp,
+  if(empty(o.owner), NULL, o.owner) AS owner, -- can be null (belongs to system contract)
+  if(empty(m.mint), NULL, m.mint) AS mint,
+  c.closed AS closed,
+  f.frozen AS frozen,
+  i.immutable AS immutable
+FROM owner_view AS o
+LEFT JOIN account_mint_view AS m USING (account)
+LEFT JOIN close_account_view AS c USING (account)
+LEFT JOIN freeze_account_view AS f USING (account)
+LEFT JOIN immutable_owner_view AS i USING (account);
+
+-- Ideal for scanning all accounts of a given mint
+CREATE OR REPLACE VIEW accounts_from_mint_view AS
+SELECT
+  m.account AS account,
+  m.program_id AS program_id,
+  m.block_num AS created_at_block_num,
+  m.timestamp AS created_at_timestamp,
   if(empty(o.owner), NULL, o.owner) AS owner, -- can be null (belongs to system contract)
   if(empty(m.mint), NULL, m.mint) AS mint,
   c.closed AS closed,

--- a/clickhouse-solana-tokens/schema.3.view.mints.sql
+++ b/clickhouse-solana-tokens/schema.3.view.mints.sql
@@ -1,0 +1,47 @@
+/* MINT (spine) */
+CREATE OR REPLACE VIEW decimals_view AS
+SELECT
+  mint,
+  max(version)   AS version,
+  max(block_num) AS block_num,
+  max(timestamp) AS timestamp,
+  argMax(a.decimals, a.version) AS decimals
+FROM decimals_state_latest AS a
+GROUP BY mint;
+
+CREATE OR REPLACE VIEW mint_authority_view AS
+SELECT
+  mint,
+  max(version)   AS version,
+  max(block_num) AS block_num,
+  max(timestamp) AS timestamp,
+  argMax(a.mint_authority, a.version) AS mint_authority
+FROM mint_authority_state_latest AS a
+GROUP BY mint;
+
+CREATE OR REPLACE VIEW freeze_authority_view AS
+SELECT
+  mint,
+  max(version)   AS version,
+  max(block_num) AS block_num,
+  max(timestamp) AS timestamp,
+  argMax(a.freeze_authority, a.version) AS freeze_authority
+FROM freeze_authority_state_latest AS a
+GROUP BY mint;
+
+/* COMBINED VIEW — decimals is required, others are optional */
+CREATE OR REPLACE VIEW mints AS
+SELECT
+  m.mint as mint,
+  m.block_num as block_num,                 -- authoritative block_num from decimals
+  m.timestamp as timestamp,                 -- authoritative timestamp from decimals
+  if(empty(o.owner), NULL, o.owner) AS update_authority, -- can be null (belongs to system contract)
+  if(empty(m.mint_authority), NULL, m.mint_authority) AS mint_authority, -- can be null (non-mintable)
+  if(empty(f.freeze_authority), NULL, f.freeze_authority) AS freeze_authority, -- can be null (non-freezable)
+  d.decimals AS decimals,
+  i.immutable AS immutable
+FROM decimals_view AS d
+LEFT JOIN accounts_owner_view AS o ON account = d.mint
+LEFT JOIN mint_authority_view AS m USING (mint)
+LEFT JOIN freeze_authority_view AS f USING (mint)
+LEFT JOIN accounts_immutable_view AS i ON (account = d.mint);

--- a/clickhouse-solana-tokens/schema.3.view.mints.sql
+++ b/clickhouse-solana-tokens/schema.3.view.mints.sql
@@ -41,7 +41,7 @@ SELECT
   d.decimals AS decimals,
   i.immutable AS immutable
 FROM decimals_view AS d
-LEFT JOIN accounts_owner_view AS o ON account = d.mint
+LEFT JOIN owner_view AS o ON o.account = d.mint
 LEFT JOIN mint_authority_view AS m USING (mint)
 LEFT JOIN freeze_authority_view AS f USING (mint)
-LEFT JOIN accounts_immutable_view AS i ON (account = d.mint);
+LEFT JOIN immutable_owner_view AS i ON i.account = d.mint;

--- a/clickhouse-solana-tokens/schema.3.view.mints.sql
+++ b/clickhouse-solana-tokens/schema.3.view.mints.sql
@@ -31,7 +31,9 @@ SELECT
   d.decimals AS decimals,
   i.immutable AS immutable
 FROM decimals_state_latest AS d
-LEFT JOIN metadata_update_authority_view AS u ON u.metadata = d.mint
+LEFT JOIN metadata_mint_state_latest AS mm USING (mint)          -- 1:1 mint -> metadata
+LEFT JOIN metadata_update_authority_view AS u USING (metadata)   -- now cheap
 LEFT JOIN mint_authority_view AS m USING (mint)
 LEFT JOIN freeze_authority_view AS f USING (mint)
-LEFT JOIN immutable_owner_view AS i ON i.account = d.mint;
+LEFT JOIN immutable_owner_view  AS i ON i.account = d.mint;
+


### PR DESCRIPTION
This pull request makes significant improvements to the Solana token ClickHouse schema, focusing on normalization, extensibility, and clarity for both accounts and mints. The changes introduce new template tables, refactor and expand materialized views, standardize naming conventions, and add new features such as immutable owner tracking and enhanced authority handling. The updates also provide new views for easier querying and analysis.

**Schema normalization and extensibility:**

* Introduced template tables (`TEMPLATE_ACCOUNTS_STATE`, `TEMPLATE_MINTS_STATE`) for accounts and mints, promoting schema reuse and easier extension. Added new fields such as `program_id` and standardized timestamp precision. [[1]](diffhunk://#diff-9a658ca4dfb2cbecfbd1ee69b6f78b5b161bb71ad3764b6df1bcd723bac5e0cdR3-R12) [[2]](diffhunk://#diff-25cf011e30eff6ab317b8667a5d2f3130907b2ff0e2ccf23d48732dacccff946L1-R92)

**Refactoring and expansion of account/mint state tables and views:**

* Split account and mint state into multiple specialized tables (e.g., `account_mint_state_latest`, `close_account_state_latest`, `freeze_account_state_latest`, `immutable_owner_state_latest`, `mint_authority_state_latest`, `freeze_authority_state_latest`, `close_mint_state_latest`, etc.), and updated all related materialized views accordingly. Added new projections and indexes for performance. [[1]](diffhunk://#diff-9a658ca4dfb2cbecfbd1ee69b6f78b5b161bb71ad3764b6df1bcd723bac5e0cdL30-R106) [[2]](diffhunk://#diff-25cf011e30eff6ab317b8667a5d2f3130907b2ff0e2ccf23d48732dacccff946L1-R92)
* Added new materialized views and logic for tracking immutable owners and close events for both accounts and mints. [[1]](diffhunk://#diff-9a658ca4dfb2cbecfbd1ee69b6f78b5b161bb71ad3764b6df1bcd723bac5e0cdL30-R106) [[2]](diffhunk://#diff-9a658ca4dfb2cbecfbd1ee69b6f78b5b161bb71ad3764b6df1bcd723bac5e0cdL133-R194) [[3]](diffhunk://#diff-35ff0c2971273c339fc8f398ee81d3f25b2a539f8b767b01127dbea637dda6afR1-R97)

**Authority and event handling improvements:**

* Added a new `set_authority` event table and corresponding materialized views to handle authority changes for freeze, mint, owner, and close events, supporting all relevant authority types.

**View standardization and new combined views:**

* Refactored and renamed account and mint views for clarity (e.g., `accounts_owner_view` → `owner_view`, `accounts_mint_view` → `account_mint_view`, etc.), and introduced new combined views (`accounts_view`, `accounts_from_owner_view`, `accounts_from_mint_view`, `mints_view`) to simplify querying and provide richer context. [[1]](diffhunk://#diff-e951134aee1759eabb50b647b93c102c5f52c0b33165ace525b2834150a874d8L2-R5) [[2]](diffhunk://#diff-e951134aee1759eabb50b647b93c102c5f52c0b33165ace525b2834150a874d8L13-R111) [[3]](diffhunk://#diff-96ce3ceea7f41e31d767232d08ce36293d2543c65f25d0496ad8ba11392a8918R1-R39)
