### PR TITLE
Fix TransferWithSeed source mapped as seed string instead of account

### DIFF
--- a/svm-transfers/clickhouse/schema.2.mv.transfers.sql
+++ b/svm-transfers/clickhouse/schema.2.mv.transfers.sql
@@ -36,13 +36,11 @@ WHERE lamports > 0;
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_system_transfer_with_seed
 TO transfers AS
 SELECT
-    * EXCEPT (lamports, source, destination, source_base, source_seed, source_owner),
+    * EXCEPT (lamports, source_base, source_seed, source_owner),
     lamports AS amount,
     'So11111111111111111111111111111111111111111' AS mint, -- native
     toUInt8(9) AS decimals,
-    source_base AS authority,
-    source_seed AS source,
-    destination AS destination
+    source_base AS authority
 FROM system_transfer_with_seed
 -- ignore 0 transfers
 WHERE lamports > 0;


### PR DESCRIPTION
Closes #78

## Summary
- The `mv_system_transfer_with_seed` materialized view was incorrectly mapping `source_seed` (the derivation seed string, e.g. `"0"`) as the `source` column in the unified `transfers` table
- The actual `source` account address was being excluded via `EXCEPT` and replaced with the seed
- Fix: keep the real `source` and `destination` columns from `system_transfer_with_seed`, only exclude the seed-specific fields (`source_base`, `source_seed`, `source_owner`)

## Root cause
```sql
-- Before (broken):
source_seed AS source,  -- "0" (the seed string, not an account address)

-- After (fixed):
-- source passes through from system_transfer_with_seed directly
```

## Test plan
- [ ] Recreate the MV and verify TransferWithSeed rows have valid base58 source addresses
- [ ] Verify the example tx `2AhX1H...` from the issue now shows the correct source

🤖 Generated with [Claude Code](https://claude.com/claude-code)