### PR TITLE
Add funded_by and allocated_data_size to token/account profiles

### DIFF
--- a/svm-accounts/clickhouse/schema.2.mv.funded_by.sql
+++ b/svm-accounts/clickhouse/schema.2.mv.funded_by.sql
@@ -1,0 +1,36 @@
+-- FUNDED BY (who funded the account creation)
+CREATE TABLE IF NOT EXISTS funded_by_state AS TEMPLATE_ACCOUNTS_STATE;
+ALTER TABLE funded_by_state
+    ADD COLUMN IF NOT EXISTS funded_by String COMMENT 'Account that funded the creation',
+    ADD COLUMN IF NOT EXISTS space UInt64 DEFAULT 0 COMMENT 'Allocated data size in bytes',
+    ADD COLUMN IF NOT EXISTS lamports UInt64 DEFAULT 0 COMMENT 'Initial balance in lamports',
+    MODIFY COLUMN is_deleted UInt8 MATERIALIZED if(funded_by = '', 1, 0),
+    ADD PROJECTION IF NOT EXISTS prj_funded_by (SELECT * ORDER BY (funded_by, account));
+
+-- system_create_account → funded_by_state
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_funded_by_state_create_account
+TO funded_by_state AS
+SELECT
+    program_id,
+    new_account AS account,
+    source AS funded_by,
+    space,
+    lamports,
+    version,
+    block_num,
+    timestamp
+FROM system_create_account;
+
+-- system_create_account_with_seed → funded_by_state
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_funded_by_state_create_account_with_seed
+TO funded_by_state AS
+SELECT
+    program_id,
+    new_account AS account,
+    source AS funded_by,
+    space,
+    lamports,
+    version,
+    block_num,
+    timestamp
+FROM system_create_account_with_seed;

--- a/svm-accounts/clickhouse/schema.3.view.accounts.sql
+++ b/svm-accounts/clickhouse/schema.3.view.accounts.sql
@@ -55,6 +55,19 @@ SELECT
 FROM immutable_owner_state AS a
 GROUP BY account;
 
+CREATE OR REPLACE VIEW funded_by_view AS
+SELECT
+  account,
+  any(program_id) AS program_id,
+  max(version)   AS version,
+  max(block_num) AS block_num,
+  max(timestamp) AS timestamp,
+  argMax(a.funded_by, a.version) AS funded_by,
+  argMax(a.space, a.version) AS space,
+  argMax(a.lamports, a.version) AS initial_lamports
+FROM funded_by_state AS a
+GROUP BY account;
+
 -- Ideal for general account lookups
 CREATE OR REPLACE VIEW accounts_view AS
 SELECT
@@ -66,13 +79,16 @@ SELECT
   if(empty(m.mint), NULL, m.mint) AS mint,
   c.closed AS closed,
   f.frozen AS frozen,
-  i.immutable AS immutable
+  i.immutable AS immutable,
+  if(empty(fb.funded_by), NULL, fb.funded_by) AS funded_by,
+  fb.space AS allocated_data_size
 FROM account_state AS a
 LEFT JOIN account_mint_view AS m USING (account)
 LEFT JOIN owner_view AS o USING (account)
 LEFT JOIN close_account_view AS c USING (account)
 LEFT JOIN freeze_account_view AS f USING (account)
-LEFT JOIN immutable_owner_view AS i USING (account);
+LEFT JOIN immutable_owner_view AS i USING (account)
+LEFT JOIN funded_by_view AS fb USING (account);
 
 -- Ideal for owner lookups (get all accounts of an owner)
 CREATE OR REPLACE VIEW accounts_from_owner_view AS
@@ -140,8 +156,10 @@ SELECT
   if(empty(m.authority), NULL, m.authority) AS mint_authority, -- can be null (non-mintable)
   if(empty(f.authority), NULL, f.authority) AS freeze_authority, -- can be null (non-freezable)
   d.decimals AS decimals,
-  i.immutable AS immutable
+  i.immutable AS immutable,
+  if(empty(fb.funded_by), NULL, fb.funded_by) AS funded_by -- who funded mint account creation
 FROM decimals_state AS d
 LEFT JOIN mint_authority_view AS m USING (mint)
 LEFT JOIN freeze_authority_view AS f USING (mint)
-LEFT JOIN immutable_owner_view  AS i ON i.account = d.mint;
+LEFT JOIN immutable_owner_view  AS i ON i.account = d.mint
+LEFT JOIN funded_by_view AS fb ON fb.account = d.mint;


### PR DESCRIPTION
Closes #67

## Summary

Adds missing fields from the Token Metadata Profile issue. Here's the full status after this PR:

### Token (Mint)
- [x] name — `metadata_view`
- [x] symbol — `metadata_view`
- [x] uri — `metadata_view`
- [x] decimals — `mints_view`
- [x] mint_authority — `mints_view` + `metadata_view`
- [x] freeze_authority — `mints_view`
- [x] update_authority — `metadata_view`
- [x] **funded_by** — `mints_view` (NEW: who funded the mint account creation)

### Account (Token Account)
- [x] owner — `accounts_view`
- [x] mint — `accounts_view`
- [x] closed — `accounts_view`
- [x] frozen — `accounts_view`
- [x] immutable — `accounts_view`
- [x] **funded_by** — `accounts_view` (NEW: who funded the account creation)
- [x] **allocated_data_size** — `accounts_view` (NEW: space in bytes)

### Already queryable (no new tables needed)
- **creator** — `initialize_mint.fee_payer` or `metaplex_create_metadata_account.payer`
- **first_mint** — `SELECT min(timestamp) FROM spl_transfer WHERE source = mint` (MintTo events have source = mint)

### Changes
- New `funded_by_state` table with MVs from `system_create_account` and `system_create_account_with_seed`
- New `funded_by_view` aggregating latest funded_by per account
- Updated `accounts_view` with `funded_by` and `allocated_data_size`
- Updated `mints_view` with `funded_by`

## Test plan
- [ ] Deploy ClickHouse schemas
- [ ] Verify funded_by populated from system_create_account events
- [ ] Verify accounts_view and mints_view return new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)