### PR TITLE
feat(metaplex): handle CreateV1 and UpdateV1 discriminators

### DIFF
--- a/metaplex/src/metadata.rs
+++ b/metaplex/src/metadata.rs
@@ -1,5 +1,7 @@
 use borsh::BorshDeserialize;
-use mpl_token_metadata::instructions::{CreateMetadataAccountV3InstructionArgs, UpdateMetadataAccountV2InstructionArgs};
+use mpl_token_metadata::instructions::{
+    CreateMetadataAccountV3InstructionArgs, CreateV1InstructionArgs, UpdateMetadataAccountV2InstructionArgs, UpdateV1InstructionArgs,
+};
 use mpl_token_metadata::types::{Data, DataV2};
 use proto::pb::solana::metaplex::v1 as pb;
 use substreams_solana::block_view::InstructionView;
@@ -9,6 +11,46 @@ use crate::is_metaplex_program;
 /// Strip null bytes and trailing whitespace from Metaplex fixed-length strings.
 fn trim_null(s: &str) -> String {
     s.trim_end_matches('\0').trim().to_string()
+}
+
+fn create_metadata_account(
+    instruction: &InstructionView,
+    metadata_index: usize,
+    mint_index: usize,
+    mint_authority_index: usize,
+    payer_index: usize,
+    update_authority_index: usize,
+    name: &str,
+    symbol: &str,
+    uri: &str,
+) -> Option<pb::instruction::Instruction> {
+    Some(pb::instruction::Instruction::CreateMetadataAccount(pb::CreateMetadataAccount {
+        metadata: instruction.accounts().get(metadata_index)?.0.to_vec(),
+        mint: instruction.accounts().get(mint_index)?.0.to_vec(),
+        mint_authority: instruction.accounts().get(mint_authority_index)?.0.to_vec(),
+        payer: instruction.accounts().get(payer_index)?.0.to_vec(),
+        update_authority: instruction.accounts().get(update_authority_index)?.0.to_vec(),
+        name: trim_null(name),
+        symbol: trim_null(symbol),
+        uri: trim_null(uri),
+    }))
+}
+
+fn update_metadata_account(
+    instruction: &InstructionView,
+    metadata_index: usize,
+    update_authority_index: usize,
+    name: Option<String>,
+    symbol: Option<String>,
+    uri: Option<String>,
+) -> Option<pb::instruction::Instruction> {
+    Some(pb::instruction::Instruction::UpdateMetadataAccount(pb::UpdateMetadataAccount {
+        metadata: instruction.accounts().get(metadata_index)?.0.to_vec(),
+        update_authority: instruction.accounts().get(update_authority_index)?.0.to_vec(),
+        name,
+        symbol,
+        uri,
+    }))
 }
 
 pub fn unpack_metadata(instruction: &InstructionView, program_id: &[u8]) -> Option<pb::instruction::Instruction> {
@@ -27,16 +69,7 @@ pub fn unpack_metadata(instruction: &InstructionView, program_id: &[u8]) -> Opti
                 // is_mutable: bool,
             }
             let args: Args = Args::deserialize(&mut rest).ok()?;
-            Some(pb::instruction::Instruction::CreateMetadataAccount(pb::CreateMetadataAccount {
-                metadata: instruction.accounts().get(0)?.0.to_vec(),
-                mint: instruction.accounts().get(1)?.0.to_vec(),
-                mint_authority: instruction.accounts().get(2)?.0.to_vec(),
-                payer: instruction.accounts().get(3)?.0.to_vec(),
-                update_authority: instruction.accounts().get(4)?.0.to_vec(),
-                name: trim_null(&args.data.name),
-                symbol: trim_null(&args.data.symbol),
-                uri: trim_null(&args.data.uri),
-            }))
+            create_metadata_account(instruction, 0, 1, 2, 3, 4, &args.data.name, &args.data.symbol, &args.data.uri)
         }
         16 => {
             #[derive(BorshDeserialize)]
@@ -45,30 +78,16 @@ pub fn unpack_metadata(instruction: &InstructionView, program_id: &[u8]) -> Opti
                 // is_mutable: bool,
             }
             let args: Args = Args::deserialize(&mut rest).ok()?;
-            Some(pb::instruction::Instruction::CreateMetadataAccount(pb::CreateMetadataAccount {
-                metadata: instruction.accounts().get(0)?.0.to_vec(),
-                mint: instruction.accounts().get(1)?.0.to_vec(),
-                mint_authority: instruction.accounts().get(2)?.0.to_vec(),
-                payer: instruction.accounts().get(3)?.0.to_vec(),
-                update_authority: instruction.accounts().get(4)?.0.to_vec(),
-                name: trim_null(&args.data.name),
-                symbol: trim_null(&args.data.symbol),
-                uri: trim_null(&args.data.uri),
-            }))
+            create_metadata_account(instruction, 0, 1, 2, 3, 4, &args.data.name, &args.data.symbol, &args.data.uri)
         }
         33 => {
             let args = CreateMetadataAccountV3InstructionArgs::deserialize(&mut rest).ok()?;
             let data = args.data;
-            Some(pb::instruction::Instruction::CreateMetadataAccount(pb::CreateMetadataAccount {
-                metadata: instruction.accounts().get(0)?.0.to_vec(),
-                mint: instruction.accounts().get(1)?.0.to_vec(),
-                mint_authority: instruction.accounts().get(2)?.0.to_vec(),
-                payer: instruction.accounts().get(3)?.0.to_vec(),
-                update_authority: instruction.accounts().get(4)?.0.to_vec(),
-                name: trim_null(&data.name),
-                symbol: trim_null(&data.symbol),
-                uri: trim_null(&data.uri),
-            }))
+            create_metadata_account(instruction, 0, 1, 2, 3, 4, &data.name, &data.symbol, &data.uri)
+        }
+        42 => {
+            let args = CreateV1InstructionArgs::deserialize(&mut rest).ok()?;
+            create_metadata_account(instruction, 0, 2, 3, 4, 5, &args.name, &args.symbol, &args.uri)
         }
         1 => {
             #[derive(BorshDeserialize)]
@@ -83,13 +102,7 @@ pub fn unpack_metadata(instruction: &InstructionView, program_id: &[u8]) -> Opti
             } else {
                 (None, None, None)
             };
-            Some(pb::instruction::Instruction::UpdateMetadataAccount(pb::UpdateMetadataAccount {
-                metadata: instruction.accounts().get(0)?.0.to_vec(),
-                update_authority: instruction.accounts().get(1)?.0.to_vec(),
-                name,
-                symbol,
-                uri,
-            }))
+            update_metadata_account(instruction, 0, 1, name, symbol, uri)
         }
         15 => {
             let args = UpdateMetadataAccountV2InstructionArgs::deserialize(&mut rest).ok()?;
@@ -98,13 +111,16 @@ pub fn unpack_metadata(instruction: &InstructionView, program_id: &[u8]) -> Opti
             } else {
                 (None, None, None)
             };
-            Some(pb::instruction::Instruction::UpdateMetadataAccount(pb::UpdateMetadataAccount {
-                metadata: instruction.accounts().get(0)?.0.to_vec(),
-                update_authority: instruction.accounts().get(1)?.0.to_vec(),
-                name,
-                symbol,
-                uri,
-            }))
+            update_metadata_account(instruction, 0, 1, name, symbol, uri)
+        }
+        50 => {
+            let args = UpdateV1InstructionArgs::deserialize(&mut rest).ok()?;
+            let (name, symbol, uri) = if let Some(data) = args.data {
+                (Some(trim_null(&data.name)), Some(trim_null(&data.symbol)), Some(trim_null(&data.uri)))
+            } else {
+                (None, None, None)
+            };
+            update_metadata_account(instruction, 4, 0, name, symbol, uri)
         }
         _ => None,
     }


### PR DESCRIPTION
## Summary

Fixes #150 by teaching the Metaplex decoder to handle the newer Token Metadata instruction discriminators:

- `42` → `CreateV1`
- `50` → `UpdateV1`

## What Changed

- added `CreateV1InstructionArgs` support in `metaplex/src/metadata.rs`
- added `UpdateV1InstructionArgs` support in `metaplex/src/metadata.rs`
- mapped `CreateV1` into the existing `CreateMetadataAccount` protobuf message
- mapped `UpdateV1` into the existing `UpdateMetadataAccount` protobuf message
- kept the output shape compatible with the current downstream `svm-metadata` pipeline
- factored the repeated create/update protobuf mapping into small helpers so legacy and V1 paths stay aligned

## Notes

The `CreateV1` account layout differs from the older create instructions, so the decoder now reads:

- `metadata` from account `0`
- `mint` from account `2`
- `mint_authority` from account `3`
- `payer` from account `4`
- `update_authority` from account `5`

The `UpdateV1` layout also differs from the older update instructions, so the decoder now reads:

- `metadata` from account `4`
- `update_authority` from account `0`

## Validation

- `cargo build -p metaplex -p svm-metadata --target wasm32-unknown-unknown --release`
