### PR TITLE
Update holders/swaps/OHLCV

### DIFF
--- a/svm-balances/clickhouse/schema.1.table.balances.sql
+++ b/svm-balances/clickhouse/schema.1.table.balances.sql
@@ -6,10 +6,14 @@ CREATE TABLE IF NOT EXISTS balances (
     timestamp       DateTime(0, 'UTC'),
 
     -- balance --
-    program_id      LowCardinality(String),
+    program_id      Enum8(
+                        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' = 1,
+                        'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' = 2
+                    ),
     mint            LowCardinality(String),
     account         String,
     amount          UInt64,
+    is_deleted      UInt8 MATERIALIZED amount = 0,
     decimals        UInt8,
 
     -- indexes --
@@ -23,7 +27,7 @@ CREATE TABLE IF NOT EXISTS balances (
     -- projections --
     PROJECTION prj_account_mint ( SELECT * ORDER BY account, program_id, mint )
 )
-ENGINE = ReplacingMergeTree(block_num)
+ENGINE = ReplacingMergeTree(block_num, is_deleted)
 ORDER BY (mint, account)
 SETTINGS deduplicate_merge_projection_mode = 'rebuild'
 COMMENT 'SPL Token balances (single balance per-block per-account/mint)';
@@ -38,6 +42,7 @@ CREATE TABLE IF NOT EXISTS native_balances (
     -- balance --
     account         String,
     amount          UInt64,
+    is_deleted      UInt8 MATERIALIZED amount = 0,
 
     -- indexes --
     INDEX idx_amount (amount) TYPE minmax GRANULARITY 1,
@@ -45,7 +50,48 @@ CREATE TABLE IF NOT EXISTS native_balances (
     -- count() --
     PROJECTION prj_count ( SELECT min(amount), max(amount), count(), max(block_num), min(block_num), max(timestamp), min(timestamp) ),
 )
-ENGINE = ReplacingMergeTree(block_num)
+ENGINE = ReplacingMergeTree(block_num, is_deleted)
 ORDER BY (account)
 SETTINGS deduplicate_merge_projection_mode = 'rebuild'
 COMMENT 'Native SOL balances (single balance per-block per-account)';
+
+-- SPL Token top holders: max 10,000 accounts per program_id/mint
+CREATE MATERIALIZED VIEW balances_holders
+REFRESH AFTER 60 MINUTE
+ENGINE = MergeTree
+ORDER BY (program_id, mint, amount DESC, account)
+SETTINGS allow_experimental_reverse_key = 1
+AS
+SELECT
+    block_num,
+    timestamp,
+    program_id,
+    mint,
+    account,
+    amount,
+    decimals
+FROM balances FINAL
+WHERE amount > 0
+ORDER BY program_id, mint, amount DESC, account
+LIMIT 10000 BY program_id, mint;
+
+-- Native SOL top holders: max 100,000 accounts total
+CREATE MATERIALIZED VIEW native_balances_holders
+REFRESH AFTER 60 MINUTE
+ENGINE = MergeTree
+ORDER BY (amount DESC, account)
+SETTINGS allow_experimental_reverse_key = 1
+AS
+SELECT
+    block_num,
+    timestamp,
+    account,
+    amount
+FROM native_balances FINAL
+WHERE amount > 0
+ORDER BY amount DESC, account
+LIMIT 100000;
+
+-- -- Optional: initialize immediately
+-- SYSTEM REFRESH VIEW balances_holders;
+-- SYSTEM REFRESH VIEW native_balances_holders;

--- a/svm-balances/clickhouse/substreams.yaml
+++ b/svm-balances/clickhouse/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: svm_clickhouse_balances
-  version: v0.3.3
+  version: v0.3.4
   url: https://github.com/pinax-network/substreams-svm
   description: SPL, SPL-2022 & Native token balances for Solana (ClickHouse).
   image: ../../image.png


### PR DESCRIPTION
This pull request introduces significant improvements to the ClickHouse schema for Solana token and native balances, focusing on more efficient storage, soft deletion support, and the addition of materialized views to track top holders. The key changes are grouped below by theme.

Schema improvements and soft deletion:

* Changed `program_id` in the `balances` table from a `LowCardinality(String)` to an `Enum8` for two known token program IDs, improving query performance and storage efficiency.
* Added an `is_deleted` column (materialized as `amount = 0`) to both `balances` and `native_balances` tables, enabling soft deletion and more robust data management. [[1]](diffhunk://#diff-2f1e7aa7dcbab1e8717f3a59bcd7f8cee5a60886115ef540102fe8b62bf35f8fL9-R16) [[2]](diffhunk://#diff-2f1e7aa7dcbab1e8717f3a59bcd7f8cee5a60886115ef540102fe8b62bf35f8fR45-R97)
* Modified the `ENGINE` of both `balances` and `native_balances` tables to use `ReplacingMergeTree` with the new `is_deleted` column, ensuring proper deduplication of deleted rows. [[1]](diffhunk://#diff-2f1e7aa7dcbab1e8717f3a59bcd7f8cee5a60886115ef540102fe8b62bf35f8fL26-R30) [[2]](diffhunk://#diff-2f1e7aa7dcbab1e8717f3a59bcd7f8cee5a60886115ef540102fe8b62bf35f8fR45-R97)

Analytics and reporting enhancements:

* Added two materialized views: `balances_holders` (tracks the top 10,000 holders per token) and `native_balances_holders` (tracks the top 100,000 SOL holders), both refreshed every 60 minutes for up-to-date analytics.

Version update:

* Bumped the package version in `substreams.yaml` from `v0.3.3` to `v0.3.4` to reflect these schema and feature enhancements.