### PR TITLE
add projection for DISTINCT mint on `state_pools_aggregating_by_mint`

### DIFF
--- a/svm-dex/clickhouse/examples/materialize.prj_mints_by_pool.sql
+++ b/svm-dex/clickhouse/examples/materialize.prj_mints_by_pool.sql
@@ -1,0 +1,48 @@
+-- Add and backfill the projection used by:
+-- SELECT DISTINCT mint
+-- FROM state_pools_aggregating_by_mint
+-- WHERE amm_pool = '...'
+
+ALTER TABLE state_pools_aggregating_by_mint
+ADD PROJECTION IF NOT EXISTS prj_mints_by_pool
+(
+    SELECT
+        amm_pool,
+        mint
+    GROUP BY amm_pool, mint
+);
+
+ALTER TABLE state_pools_aggregating_by_mint
+MATERIALIZE PROJECTION prj_mints_by_pool;
+
+-- Check active / recent projection materialization mutations.
+SELECT
+    database,
+    table,
+    mutation_id,
+    command,
+    parts_to_do,
+    is_done,
+    latest_fail_reason
+FROM system.mutations
+WHERE table = 'state_pools_aggregating_by_mint'
+ORDER BY create_time DESC;
+
+-- Check whether projection parts have been built.
+SELECT
+    database,
+    table,
+    parent_name,
+    name,
+    active,
+    count() AS parts
+FROM system.projection_parts
+WHERE table = 'state_pools_aggregating_by_mint'
+GROUP BY database, table, parent_name, name, active
+ORDER BY name, active DESC;
+
+-- Confirm the optimizer can use the projection for pool -> mint lookup.
+EXPLAIN indexes = 1
+SELECT DISTINCT mint
+FROM state_pools_aggregating_by_mint
+WHERE amm_pool = 'AmmpSnW5xVeKHTAU9fMjyKEMPgrzmUj3ah5vgvHhAB5J';

--- a/svm-dex/clickhouse/schema.3.mv.state_pools_aggregating_by_mint.sql
+++ b/svm-dex/clickhouse/schema.3.mv.state_pools_aggregating_by_mint.sql
@@ -44,6 +44,8 @@ CREATE TABLE IF NOT EXISTS state_pools_aggregating_by_mint (
     INDEX idx_transactions      (transactions)               TYPE minmax             GRANULARITY 1,
 
     -- projections --
+    -- optimize for distinct mints by pool --
+    PROJECTION prj_mints_by_pool ( SELECT amm_pool, mint GROUP BY amm_pool, mint ),
     -- optimize for universal summary & distinct mints --
     PROJECTION prj_group_by_pool (
         SELECT


### PR DESCRIPTION
This pull request introduces a new projection to the `state_pools_aggregating_by_mint` table in ClickHouse to optimize queries that select distinct mints by pool. The changes include both the schema update and an example SQL script for adding, materializing, and verifying the new projection.

Schema and performance improvements:

* Added a new projection `prj_mints_by_pool` to the `state_pools_aggregating_by_mint` table to optimize queries for distinct mints by pool. (`svm-dex/clickhouse/schema.3.mv.state_pools_aggregating_by_mint.sql`)

Operational and usage guidance:

* Provided an example SQL script to add, materialize, and validate the `prj_mints_by_pool` projection, including commands to check mutation status, projection part building, and optimizer usage. (`svm-dex/clickhouse/examples/materialize.prj_mints_by_pool.sql`)

## SQL PROJECTION

```sql
PROJECTION prj_mints_by_pool ( SELECT amm_pool, mint GROUP BY amm_pool, mint ),
```