### PR TITLE
fix(dex-swaps): populate amm_pool on Jupiter-routed swaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,8 +3059,8 @@ dependencies = [
 
 [[package]]
 name = "substreams-solana-idls"
-version = "1.1.1"
-source = "git+https://github.com/pinax-network/substreams-solana-idls?tag=v1.1.2#87d5278a25698b91d20fb64805ebffd38701649b"
+version = "1.1.3"
+source = "git+https://github.com/pinax-network/substreams-solana-idls?tag=v1.1.3#bd3af5eec3d9f15d8fa1c872c2a36d290cbff6ad"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ bs58 = "0.5.1"
 substreams = "0.7.3"
 substreams-abis = "0.7.12"
 substreams-solana = "0.14.2"
-substreams-solana-idls = { git = "https://github.com/pinax-network/substreams-solana-idls", tag = "v1.1.2" }
+substreams-solana-idls = { git = "https://github.com/pinax-network/substreams-solana-idls", tag = "v1.1.3" }
 spl-token = "9.0.0"
 substreams-solana-program-instructions = "0.3"
 substreams-database-change = "4.0.0"

--- a/dex-swaps/src/jupiter_v4.rs
+++ b/dex-swaps/src/jupiter_v4.rs
@@ -4,6 +4,7 @@ use substreams_solana::pb::sf::solana::r#type::v1::ConfirmedTransaction;
 use substreams_solana_idls::jupiter;
 
 use crate::logs::{scoped_program_log, ProgramLog};
+use crate::routed_pool::Tracker;
 
 pub(crate) struct State {
     is_invoked: bool,
@@ -18,7 +19,12 @@ impl State {
         }
     }
 
-    pub(crate) fn handle_log(&mut self, tx: &ConfirmedTransaction, log_message: &str) -> Option<pb::Swap> {
+    pub(crate) fn handle_log(
+        &mut self,
+        tx: &ConfirmedTransaction,
+        log_message: &str,
+        routed_pools: &Tracker,
+    ) -> Option<pb::Swap> {
         match scoped_program_log(log_message, &jupiter::v4::PROGRAM_ID.to_vec(), &mut self.is_invoked)? {
             ProgramLog::Enter {
                 invoke_depth: Some(height),
@@ -30,12 +36,17 @@ impl State {
             ProgramLog::Data(log_message) => {
                 let data = parse_program_data(log_message)?;
                 if let Ok(jupiter::v4::events::JupiterV4Event::Swap(event)) = jupiter::v4::events::unpack(data.as_slice()) {
+                    let amm_program = event.amm.to_bytes();
+                    let amm_pool = routed_pools
+                        .lookup(&amm_program)
+                        .cloned()
+                        .unwrap_or_default();
                     return Some(pb::Swap {
                         program_id: jupiter::v4::PROGRAM_ID.to_vec(),
                         protocol: pb::Protocol::JupiterV4 as i32,
                         stack_height: self.current_stack_height,
-                        amm: event.amm.to_bytes().to_vec(),
-                        amm_pool: [].to_vec(),
+                        amm: amm_program.to_vec(),
+                        amm_pool,
                         user: get_fee_payer(&tx).unwrap_or_default(),
                         input_mint: event.input_mint.to_bytes().to_vec(),
                         input_amount: event.input_amount,

--- a/dex-swaps/src/jupiter_v6.rs
+++ b/dex-swaps/src/jupiter_v6.rs
@@ -3,25 +3,127 @@ use proto::pb::dex::swaps::v1 as pb;
 use substreams_solana::{block_view::InstructionView, pb::sf::solana::r#type::v1::ConfirmedTransaction};
 use substreams_solana_idls::jupiter;
 
-pub(crate) fn decode_instruction(tx: &ConfirmedTransaction, instruction: &InstructionView) -> Option<pb::Swap> {
+use crate::routed_pool::Tracker;
+
+/// Discriminator for the Jupiter v6 `Swap` self-CPI event log. Mirrors the
+/// private constant in `substreams_solana_idls::jupiter::v6::events` so we can
+/// build fixtures without exposing it upstream.
+#[cfg(test)]
+const SWAP_DISCRIMINATOR: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+
+pub(crate) fn decode_instruction(
+    tx: &ConfirmedTransaction,
+    instruction: &InstructionView,
+    routed_pools: &Tracker,
+) -> Option<pb::Swap> {
     let program_id = instruction.program_id().0;
     if program_id != &jupiter::v6::PROGRAM_ID {
         return None;
     }
 
     match jupiter::v6::events::unpack(instruction.data()) {
-        Ok(jupiter::v6::events::JupiterV6Event::Swap(event)) => Some(pb::Swap {
-            program_id: jupiter::v6::PROGRAM_ID.to_vec(),
-            protocol: pb::Protocol::JupiterV6 as i32,
-            stack_height: instruction.stack_height(),
-            amm: event.amm.to_bytes().to_vec(),
-            amm_pool: [].to_vec(),
-            user: get_fee_payer(tx).unwrap_or_default(),
-            input_mint: event.input_mint.to_bytes().to_vec(),
-            input_amount: event.input_amount,
-            output_mint: event.output_mint.to_bytes().to_vec(),
-            output_amount: event.output_amount,
-        }),
+        Ok(jupiter::v6::events::JupiterV6Event::Swap(event)) => {
+            let amm_program = event.amm.to_bytes();
+            let amm_pool = routed_pools
+                .lookup(&amm_program)
+                .cloned()
+                .unwrap_or_default();
+            Some(pb::Swap {
+                program_id: jupiter::v6::PROGRAM_ID.to_vec(),
+                protocol: pb::Protocol::JupiterV6 as i32,
+                stack_height: instruction.stack_height(),
+                amm: amm_program.to_vec(),
+                amm_pool,
+                user: get_fee_payer(tx).unwrap_or_default(),
+                input_mint: event.input_mint.to_bytes().to_vec(),
+                input_amount: event.input_amount,
+                output_mint: event.output_mint.to_bytes().to_vec(),
+                output_amount: event.output_amount,
+            })
+        }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routed_pool::test_fixture::make_tx;
+    use substreams_solana_idls::pumpfun;
+
+    /// PumpSwap (`pumpfun::amm`) Buy discriminator. Mirrors the private
+    /// constant in `substreams_solana_idls::pumpfun::amm::instructions`.
+    const PUMPFUN_AMM_BUY: [u8; 8] = [102, 6, 61, 18, 1, 218, 235, 234];
+
+    /// Build a Jupiter v6 Swap-event instruction data payload with the given
+    /// routed AMM and amounts. Matches the on-chain layout: 8 bytes event
+    /// discriminator + 8 bytes Anchor discriminator + 112 bytes Borsh-serialised
+    /// `SwapEvent { amm, input_mint, input_amount, output_mint, output_amount }`.
+    fn jup_swap_event_data(amm: [u8; 32], input_mint: [u8; 32], input_amount: u64, output_mint: [u8; 32], output_amount: u64) -> Vec<u8> {
+        let mut data = SWAP_DISCRIMINATOR.to_vec();
+        data.extend_from_slice(&[0u8; 8]); // anchor discriminator (ignored by parser)
+        data.extend_from_slice(&amm);
+        data.extend_from_slice(&input_mint);
+        data.extend_from_slice(&input_amount.to_le_bytes());
+        data.extend_from_slice(&output_mint);
+        data.extend_from_slice(&output_amount.to_le_bytes());
+        data
+    }
+
+    #[test]
+    fn populates_amm_pool_from_routed_inner_cpi() {
+        // Pre-record a PumpSwap pool in the tracker, as Tracker::observe would
+        // during the walk.
+        let pool = [9u8; 32];
+        let mints_and_filler = [[2u8; 32], [3u8; 32], [4u8; 32], [5u8; 32], [6u8; 32]];
+        let mut accounts = vec![pool];
+        accounts.extend_from_slice(&mints_and_filler);
+        let mut data = PUMPFUN_AMM_BUY.to_vec();
+        data.extend_from_slice(&100_000u64.to_le_bytes());
+        data.extend_from_slice(&50_000u64.to_le_bytes());
+        let routed_tx = make_tx(pumpfun::amm::PROGRAM_ID, &accounts, data);
+        let mut tracker = Tracker::new();
+        for ix in routed_tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+
+        // Build a Jupiter v6 Swap event referencing the routed program.
+        let input_mint = [11u8; 32];
+        let output_mint = [12u8; 32];
+        let event_data = jup_swap_event_data(pumpfun::amm::PROGRAM_ID, input_mint, 1_000, output_mint, 900);
+        let jup_tx = make_tx(jupiter::v6::PROGRAM_ID, &[], event_data);
+
+        let instruction = jup_tx.walk_instructions().next().unwrap();
+        let swap = decode_instruction(&jup_tx, &instruction, &tracker).expect("swap emitted");
+
+        assert_eq!(swap.amm, pumpfun::amm::PROGRAM_ID.to_vec());
+        assert_eq!(swap.amm_pool, pool.to_vec(), "pool from tracker should populate amm_pool");
+        assert_eq!(swap.input_amount, 1_000);
+        assert_eq!(swap.output_amount, 900);
+    }
+
+    #[test]
+    fn unknown_routed_amm_emits_empty_pool() {
+        // No tracker entries → Jupiter event for an unknown AMM emits an empty
+        // pool (current behaviour, just no longer hardcoded at the call site).
+        let tracker = Tracker::new();
+        let unknown_amm = [42u8; 32];
+        let event_data = jup_swap_event_data(unknown_amm, [1u8; 32], 1, [2u8; 32], 1);
+        let jup_tx = make_tx(jupiter::v6::PROGRAM_ID, &[], event_data);
+
+        let instruction = jup_tx.walk_instructions().next().unwrap();
+        let swap = decode_instruction(&jup_tx, &instruction, &tracker).expect("swap emitted");
+
+        assert_eq!(swap.amm, unknown_amm.to_vec());
+        assert!(swap.amm_pool.is_empty());
+    }
+
+    #[test]
+    fn non_jupiter_program_yields_nothing() {
+        let tracker = Tracker::new();
+        let some_program = [99u8; 32];
+        let tx = make_tx(some_program, &[[1u8; 32]], vec![0u8; 128]);
+        let instruction = tx.walk_instructions().next().unwrap();
+        assert!(decode_instruction(&tx, &instruction, &tracker).is_none());
     }
 }

--- a/dex-swaps/src/lib.rs
+++ b/dex-swaps/src/lib.rs
@@ -2,6 +2,7 @@
 mod jupiter_v4;
 mod jupiter_v6;
 mod logs;
+mod routed_pool;
 mod boop;
 mod darklake;
 mod dumpfun;
@@ -45,9 +46,11 @@ fn process_transaction(tx: ConfirmedTransaction) -> Option<pb::Transaction> {
     let mut raydium_clmm_state = raydium_clmm::State::new();
     let mut raydium_cpmm_state = raydium_cpmm::State::new();
     let mut orca_whirlpool_state = orca_whirlpool::State::new();
+    let mut routed_pools = routed_pool::Tracker::new();
 
     for instruction in tx.walk_instructions() {
-        if let Some(swap) = jupiter_v6::decode_instruction(&tx, &instruction) {
+        routed_pools.observe(&instruction);
+        if let Some(swap) = jupiter_v6::decode_instruction(&tx, &instruction, &routed_pools) {
             swaps.push(swap);
         }
         darklake_state.handle_instruction(&instruction);
@@ -72,7 +75,7 @@ fn process_transaction(tx: ConfirmedTransaction) -> Option<pb::Transaction> {
 
     let mut jupiter_v4_state = jupiter_v4::State::new();
     for log_message in tx_meta.log_messages.iter() {
-        if let Some(swap) = jupiter_v4_state.handle_log(&tx, log_message) {
+        if let Some(swap) = jupiter_v4_state.handle_log(&tx, log_message, &routed_pools) {
             swaps.push(swap);
         }
         if let Some(swap) = boop_state.handle_log(log_message) {

--- a/dex-swaps/src/meteora_dlmm.rs
+++ b/dex-swaps/src/meteora_dlmm.rs
@@ -48,6 +48,13 @@ pub(crate) fn handle_instruction(pending_swap: &mut Option<PendingSwap>, instruc
     })
 }
 
+pub(crate) fn extract_pool(ix: &InstructionView) -> Option<Vec<u8>> {
+    if ix.program_id().0 != &dlmm::PROGRAM_ID {
+        return None;
+    }
+    decode_swap_instruction(ix).map(|s| s.lb_pair)
+}
+
 fn decode_swap_instruction(ix: &InstructionView) -> Option<PendingSwap> {
     match dlmm::instructions::unpack(ix.data()) {
         Ok(dlmm::instructions::MeteoraDlmmInstruction::Swap(_)) => {

--- a/dex-swaps/src/orca_whirlpool.rs
+++ b/dex-swaps/src/orca_whirlpool.rs
@@ -72,6 +72,10 @@ struct LogSwap {
     output_amount: u64,
 }
 
+pub(crate) fn extract_pool(ix: &InstructionView) -> Option<Vec<u8>> {
+    decode_instruction(ix).map(|s| s.whirlpool)
+}
+
 fn decode_instruction(ix: &InstructionView) -> Option<InstructionSwap> {
     let program_id = ix.program_id().0;
     if program_id != &orca::whirlpool::PROGRAM_ID {

--- a/dex-swaps/src/pumpfun.rs
+++ b/dex-swaps/src/pumpfun.rs
@@ -44,6 +44,13 @@ pub(crate) fn handle_instruction(pending_trade: &mut Option<PendingTrade>, instr
     })
 }
 
+pub(crate) fn extract_pool(instruction: &InstructionView) -> Option<Vec<u8>> {
+    if instruction.program_id().0 != &pumpfun::PROGRAM_ID {
+        return None;
+    }
+    decode_trade_instruction(instruction).map(|t| t.bonding_curve)
+}
+
 fn decode_trade_instruction(instruction: &InstructionView) -> Option<PendingTrade> {
     match pumpfun::instructions::unpack(instruction.data()) {
         Ok(pumpfun::instructions::PumpFunInstruction::Buy(_))

--- a/dex-swaps/src/pumpfun_amm.rs
+++ b/dex-swaps/src/pumpfun_amm.rs
@@ -48,9 +48,17 @@ pub(crate) fn handle_instruction(pending_trade: &mut Option<PendingTrade>, instr
     })
 }
 
+pub(crate) fn extract_pool(instruction: &InstructionView) -> Option<Vec<u8>> {
+    if instruction.program_id().0 != &pumpfun_amm::PROGRAM_ID {
+        return None;
+    }
+    decode_trade_instruction(instruction).map(|t| t.pool)
+}
+
 fn decode_trade_instruction(instruction: &InstructionView) -> Option<PendingTrade> {
     match pumpfun_amm::instructions::unpack(instruction.data()) {
         Ok(pumpfun_amm::instructions::PumpFunAmmInstruction::Buy(_))
+        | Ok(pumpfun_amm::instructions::PumpFunAmmInstruction::BuyExactQuoteIn(_))
         | Ok(pumpfun_amm::instructions::PumpFunAmmInstruction::Sell(_)) => Some(PendingTrade {
             pool: instruction.accounts().get(0)?.0.to_vec(),
             base_mint: instruction.accounts().get(4)?.0.to_vec(),

--- a/dex-swaps/src/raydium_amm_v4.rs
+++ b/dex-swaps/src/raydium_amm_v4.rs
@@ -73,6 +73,10 @@ struct LogSwap {
     amount_out: u64,
 }
 
+pub(crate) fn extract_pool(ix: &InstructionView) -> Option<Vec<u8>> {
+    decode_instruction(ix).map(|s| s.amm)
+}
+
 fn decode_instruction(ix: &InstructionView) -> Option<InstructionSwap> {
     let program_id = ix.program_id().0;
     if program_id != &raydium::amm::v4::PROGRAM_ID {

--- a/dex-swaps/src/raydium_clmm.rs
+++ b/dex-swaps/src/raydium_clmm.rs
@@ -72,6 +72,10 @@ struct LogSwap {
     zero_for_one: bool,
 }
 
+pub(crate) fn extract_pool(ix: &InstructionView) -> Option<Vec<u8>> {
+    decode_instruction(ix).map(|s| s.pool_state)
+}
+
 fn decode_instruction(ix: &InstructionView) -> Option<InstructionSwap> {
     let program_id = ix.program_id().0;
     if program_id != &raydium::clmm::v3::PROGRAM_ID {

--- a/dex-swaps/src/raydium_cpmm.rs
+++ b/dex-swaps/src/raydium_cpmm.rs
@@ -67,6 +67,10 @@ struct LogSwap {
     output_mint: Option<Vec<u8>>,
 }
 
+pub(crate) fn extract_pool(ix: &InstructionView) -> Option<Vec<u8>> {
+    decode_cpmm_instruction(ix).map(|s| s.pool_state)
+}
+
 fn decode_cpmm_instruction(ix: &InstructionView) -> Option<InstructionSwap> {
     let program_id = ix.program_id().0;
     if program_id != &raydium::cpmm::PROGRAM_ID {

--- a/dex-swaps/src/raydium_launchpad.rs
+++ b/dex-swaps/src/raydium_launchpad.rs
@@ -48,6 +48,13 @@ pub(crate) fn handle_instruction(pending_trade: &mut Option<PendingTrade>, instr
     })
 }
 
+pub(crate) fn extract_pool(ix: &InstructionView) -> Option<Vec<u8>> {
+    if ix.program_id().0 != &raydium::launchpad::PROGRAM_ID {
+        return None;
+    }
+    decode_trade_instruction(ix).map(|t| t.pool_state)
+}
+
 fn decode_trade_instruction(ix: &InstructionView) -> Option<PendingTrade> {
     let trade = match raydium::launchpad::instructions::unpack(ix.data()) {
         Ok(raydium::launchpad::instructions::RaydiumLaunchpadInstruction::BuyExactIn(_evt)) => {

--- a/dex-swaps/src/routed_pool.rs
+++ b/dex-swaps/src/routed_pool.rs
@@ -1,0 +1,307 @@
+//! Pool-account lookup for AMMs reached via Jupiter CPI.
+//!
+//! Jupiter v4/v6 Swap events carry the routed AMM program but not the pool
+//! account. As we walk a transaction's instructions, [Tracker::observe] feeds
+//! each non-Jupiter ix to the per-AMM `extract_pool` helper and remembers the
+//! pool keyed by program id; Jupiter handlers later look it up via
+//! [Tracker::lookup] when emitting their swap row.
+//!
+//! The dispatch list mirrors which AMMs have per-AMM pool decoders in this
+//! crate. Add new AMMs as their decoders land.
+
+use std::collections::HashMap;
+
+use substreams_solana::block_view::InstructionView;
+
+pub(crate) struct Tracker {
+    pools: HashMap<[u8; 32], Vec<u8>>,
+}
+
+impl Tracker {
+    pub(crate) fn new() -> Self {
+        Self { pools: HashMap::new() }
+    }
+
+    pub(crate) fn observe(&mut self, ix: &InstructionView) {
+        let Ok(program_id) = TryInto::<[u8; 32]>::try_into(ix.program_id().0.as_slice()) else {
+            return;
+        };
+        if let Some(pool) = dispatch(ix) {
+            self.pools.insert(program_id, pool);
+        }
+    }
+
+    pub(crate) fn lookup(&self, program_id: &[u8; 32]) -> Option<&Vec<u8>> {
+        self.pools.get(program_id)
+    }
+}
+
+fn dispatch(ix: &InstructionView) -> Option<Vec<u8>> {
+    crate::pumpfun_amm::extract_pool(ix)
+        .or_else(|| crate::raydium_amm_v4::extract_pool(ix))
+        .or_else(|| crate::raydium_clmm::extract_pool(ix))
+        .or_else(|| crate::raydium_cpmm::extract_pool(ix))
+        .or_else(|| crate::orca_whirlpool::extract_pool(ix))
+        .or_else(|| crate::meteora_dlmm::extract_pool(ix))
+        .or_else(|| crate::pumpfun::extract_pool(ix))
+        .or_else(|| crate::raydium_launchpad::extract_pool(ix))
+}
+
+#[cfg(test)]
+pub(crate) mod test_fixture {
+    //! Helpers for building minimal `pb::ConfirmedTransaction` fixtures so
+    //! per-AMM `extract_pool` functions can be exercised in unit tests.
+    //!
+    //! A fixture is a single compiled instruction with `program_id` at index 0
+    //! of the message account_keys, followed by the supplied `accounts` (each
+    //! gets its own account_keys slot). The instruction's `accounts` list
+    //! references those by index.
+    use substreams_solana::pb::sf::solana::r#type::v1::{
+        CompiledInstruction, ConfirmedTransaction, Message, MessageHeader, Transaction,
+        TransactionStatusMeta,
+    };
+
+    pub(crate) fn make_tx(program: [u8; 32], accounts: &[[u8; 32]], data: Vec<u8>) -> ConfirmedTransaction {
+        let mut keys: Vec<Vec<u8>> = vec![program.to_vec()];
+        let mut acc_idx: Vec<u8> = Vec::new();
+        for (i, a) in accounts.iter().enumerate() {
+            keys.push(a.to_vec());
+            acc_idx.push((i + 1) as u8);
+        }
+        ConfirmedTransaction {
+            transaction: Some(Transaction {
+                signatures: vec![vec![0u8; 64]],
+                message: Some(Message {
+                    header: Some(MessageHeader {
+                        num_required_signatures: 1,
+                        num_readonly_signed_accounts: 0,
+                        num_readonly_unsigned_accounts: 0,
+                    }),
+                    account_keys: keys,
+                    recent_blockhash: vec![0u8; 32],
+                    instructions: vec![CompiledInstruction {
+                        program_id_index: 0,
+                        accounts: acc_idx,
+                        data,
+                    }],
+                    versioned: false,
+                    address_table_lookups: vec![],
+                }),
+            }),
+            meta: Some(TransactionStatusMeta::default()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use substreams_solana_idls::{pumpfun, raydium};
+
+    /// PumpSwap (`pumpfun::amm`) Buy discriminator. Mirrors the private
+    /// constant in `substreams_solana_idls::pumpfun::amm::instructions`.
+    const PUMPFUN_AMM_BUY: [u8; 8] = [102, 6, 61, 18, 1, 218, 235, 234];
+
+    #[test]
+    fn tracker_observe_records_pool_for_known_amm() {
+        let pool = [9u8; 32];
+        let mints_and_filler = [[2u8; 32], [3u8; 32], [4u8; 32], [5u8; 32], [6u8; 32]];
+        let mut accounts = vec![pool];
+        accounts.extend_from_slice(&mints_and_filler);
+
+        // PumpSwap Buy: 8-byte discriminator + 2 u64s (base_amount_out, max_quote_amount_in).
+        let mut data = PUMPFUN_AMM_BUY.to_vec();
+        data.extend_from_slice(&100_000u64.to_le_bytes());
+        data.extend_from_slice(&50_000u64.to_le_bytes());
+
+        let tx = test_fixture::make_tx(pumpfun::amm::PROGRAM_ID, &accounts, data);
+        let mut tracker = Tracker::new();
+        for ix in tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+
+        assert_eq!(tracker.lookup(&pumpfun::amm::PROGRAM_ID), Some(&pool.to_vec()));
+    }
+
+    #[test]
+    fn tracker_observe_skips_unknown_program() {
+        let unknown_program = [42u8; 32];
+        let tx = test_fixture::make_tx(unknown_program, &[[1u8; 32], [2u8; 32]], vec![0u8; 8]);
+        let mut tracker = Tracker::new();
+        for ix in tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+        assert!(tracker.lookup(&unknown_program).is_none());
+    }
+
+    #[test]
+    fn tracker_lookup_missing_returns_none() {
+        let tracker = Tracker::new();
+        assert!(tracker.lookup(&[7u8; 32]).is_none());
+    }
+
+    /// Build a long account list with `pool` placed at `pool_index`. Fills
+    /// every other slot with deterministic non-pool bytes so IDL-typed account
+    /// extractors can satisfy their `get_req` indices.
+    fn accounts_with_pool(pool: [u8; 32], pool_index: usize, total: usize) -> Vec<[u8; 32]> {
+        let mut accounts: Vec<[u8; 32]> = (0..total).map(|i| [(i as u8).wrapping_add(50); 32]).collect();
+        accounts[pool_index] = pool;
+        accounts
+    }
+
+    #[test]
+    fn tracker_observe_handles_pumpfun_amm_buy_exact_quote_in() {
+        // PumpSwap BuyExactQuoteIn: this is the variant Jupiter routes to,
+        // not the default Buy. Pool index is the same (accounts[0]).
+        const PUMPFUN_AMM_BUY_EXACT_QUOTE_IN: [u8; 8] = [198, 46, 21, 82, 180, 217, 232, 112];
+        let pool = [27u8; 32];
+        let mints_and_filler = [[2u8; 32], [3u8; 32], [4u8; 32], [5u8; 32], [6u8; 32]];
+        let mut accounts = vec![pool];
+        accounts.extend_from_slice(&mints_and_filler);
+        let mut data = PUMPFUN_AMM_BUY_EXACT_QUOTE_IN.to_vec();
+        // Real on-chain payload is 16 bytes (two u64s: quote_amount_in, min_base_amount_out).
+        data.extend_from_slice(&100_000u64.to_le_bytes());
+        data.extend_from_slice(&50_000u64.to_le_bytes());
+
+        let tx = test_fixture::make_tx(pumpfun::amm::PROGRAM_ID, &accounts, data);
+        let mut tracker = Tracker::new();
+        for ix in tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+        assert_eq!(tracker.lookup(&pumpfun::amm::PROGRAM_ID), Some(&pool.to_vec()));
+    }
+
+    #[test]
+    fn tracker_observe_handles_pumpfun_bonding_curve() {
+        // Pumpfun bonding curve: pool at accounts[3] on Buy/Sell.
+        const PUMPFUN_BUY: [u8; 8] = [102, 6, 61, 18, 1, 218, 235, 234];
+        let pool = [21u8; 32];
+        let accounts = accounts_with_pool(pool, 3, 12);
+        let mut data = PUMPFUN_BUY.to_vec();
+        data.extend_from_slice(&100_000u64.to_le_bytes());
+        data.extend_from_slice(&50_000u64.to_le_bytes());
+        let tx = test_fixture::make_tx(pumpfun::bonding_curve::PROGRAM_ID, &accounts, data);
+        let mut tracker = Tracker::new();
+        for ix in tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+        assert_eq!(tracker.lookup(&pumpfun::bonding_curve::PROGRAM_ID), Some(&pool.to_vec()));
+    }
+
+    #[test]
+    fn tracker_observe_handles_meteora_dlmm() {
+        // Meteora DLMM Swap: lb_pair at accounts[0] (per SwapAccounts IDL).
+        const METEORA_DLMM_SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+        use substreams_solana_idls::meteora;
+        let pool = [22u8; 32];
+        let accounts = accounts_with_pool(pool, 0, 16);
+        let mut data = METEORA_DLMM_SWAP.to_vec();
+        data.extend_from_slice(&100_000u64.to_le_bytes());
+        data.extend_from_slice(&50_000u64.to_le_bytes());
+        let tx = test_fixture::make_tx(meteora::dlmm::PROGRAM_ID, &accounts, data);
+        let mut tracker = Tracker::new();
+        for ix in tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+        assert_eq!(tracker.lookup(&meteora::dlmm::PROGRAM_ID), Some(&pool.to_vec()));
+    }
+
+    #[test]
+    fn tracker_observe_handles_raydium_clmm() {
+        // Raydium CLMM Swap: pool_state at accounts[2].
+        const RAYDIUM_CLMM_SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+        let pool = [23u8; 32];
+        let accounts = accounts_with_pool(pool, 2, 14);
+        let mut data = RAYDIUM_CLMM_SWAP.to_vec();
+        data.extend_from_slice(&100_000u64.to_le_bytes()); // amount
+        data.extend_from_slice(&50_000u64.to_le_bytes());  // other_amount_threshold
+        data.extend_from_slice(&0u128.to_le_bytes());      // sqrt_price_limit_x64
+        data.push(1);                                      // is_base_input
+        let tx = test_fixture::make_tx(raydium::clmm::v3::PROGRAM_ID, &accounts, data);
+        let mut tracker = Tracker::new();
+        for ix in tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+        assert_eq!(tracker.lookup(&raydium::clmm::v3::PROGRAM_ID), Some(&pool.to_vec()));
+    }
+
+    #[test]
+    fn tracker_observe_handles_raydium_cpmm() {
+        // Raydium CPMM SwapBaseInput: pool_state at accounts[3].
+        const RAYDIUM_CPMM_SWAP_BASE_INPUT: [u8; 8] = [143, 190, 90, 218, 196, 30, 51, 222];
+        let pool = [24u8; 32];
+        let accounts = accounts_with_pool(pool, 3, 14);
+        let mut data = RAYDIUM_CPMM_SWAP_BASE_INPUT.to_vec();
+        data.extend_from_slice(&100_000u64.to_le_bytes()); // amount_in
+        data.extend_from_slice(&50_000u64.to_le_bytes());  // minimum_amount_out
+        let tx = test_fixture::make_tx(raydium::cpmm::PROGRAM_ID, &accounts, data);
+        let mut tracker = Tracker::new();
+        for ix in tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+        assert_eq!(tracker.lookup(&raydium::cpmm::PROGRAM_ID), Some(&pool.to_vec()));
+    }
+
+    #[test]
+    fn tracker_observe_handles_orca_whirlpool() {
+        // Orca Whirlpool Swap: whirlpool at accounts[2].
+        const ORCA_SWAP: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+        use substreams_solana_idls::orca;
+        let pool = [25u8; 32];
+        let accounts = accounts_with_pool(pool, 2, 14);
+        let mut data = ORCA_SWAP.to_vec();
+        data.extend_from_slice(&100_000u64.to_le_bytes()); // amount
+        data.extend_from_slice(&50_000u64.to_le_bytes());  // other_amount_threshold
+        data.extend_from_slice(&0u128.to_le_bytes());      // sqrt_price_limit
+        data.push(1);                                      // amount_specified_is_input
+        data.push(1);                                      // a_to_b
+        let tx = test_fixture::make_tx(orca::whirlpool::PROGRAM_ID, &accounts, data);
+        let mut tracker = Tracker::new();
+        for ix in tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+        assert_eq!(tracker.lookup(&orca::whirlpool::PROGRAM_ID), Some(&pool.to_vec()));
+    }
+
+    #[test]
+    fn tracker_observe_handles_raydium_launchpad() {
+        // Raydium Launchpad BuyExactIn: pool_state index per IDL.
+        const LAUNCHPAD_BUY_EXACT_IN: [u8; 8] = [250, 234, 13, 123, 213, 156, 19, 236];
+        let pool = [26u8; 32];
+        // Try a generous account count + place pool at typical pool_state index;
+        // adjust if assertion fails.
+        let accounts = accounts_with_pool(pool, 4, 18);
+        let mut data = LAUNCHPAD_BUY_EXACT_IN.to_vec();
+        data.extend_from_slice(&100_000u64.to_le_bytes()); // amount_in
+        data.extend_from_slice(&50_000u64.to_le_bytes());  // minimum_amount_out
+        data.extend_from_slice(&0u64.to_le_bytes());       // share_fee_rate
+        let tx = test_fixture::make_tx(raydium::launchpad::PROGRAM_ID, &accounts, data);
+        let mut tracker = Tracker::new();
+        for ix in tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+        assert_eq!(tracker.lookup(&raydium::launchpad::PROGRAM_ID), Some(&pool.to_vec()));
+    }
+
+    #[test]
+    fn tracker_observe_handles_raydium_amm_v4() {
+        // Raydium AMM v4 SwapBaseIn: program_id + accounts[1] = pool.
+        // Account count chooses the offset (without target_orders → 17 accounts).
+        let pool = [11u8; 32];
+        let mut accounts: Vec<[u8; 32]> = (0..17).map(|i| [i as u8 + 100; 32]).collect();
+        accounts[1] = pool;
+
+        // SwapBaseIn discriminator is a single byte (9), then two u64s.
+        // raydium::amm::v4::instructions reads u8 prefix.
+        let mut data = vec![9u8];
+        data.extend_from_slice(&100_000u64.to_le_bytes());
+        data.extend_from_slice(&50_000u64.to_le_bytes());
+
+        let tx = test_fixture::make_tx(raydium::amm::v4::PROGRAM_ID, &accounts, data);
+        let mut tracker = Tracker::new();
+        for ix in tx.walk_instructions() {
+            tracker.observe(&ix);
+        }
+        assert_eq!(tracker.lookup(&raydium::amm::v4::PROGRAM_ID), Some(&pool.to_vec()));
+    }
+}

--- a/dex-swaps/src/routed_pool.rs
+++ b/dex-swaps/src/routed_pool.rs
@@ -8,6 +8,24 @@
 //!
 //! The dispatch list mirrors which AMMs have per-AMM pool decoders in this
 //! crate. Add new AMMs as their decoders land.
+//!
+//! ## Per-program latest-wins
+//!
+//! `Tracker` stores a single pool per program id; `observe` overwrites prior
+//! observations. This is correct for **Jupiter v6**: each Swap event self-CPI
+//! is emitted immediately after the routed AMM's inner CPI in DFS walk order,
+//! so by the time the v6 handler does `lookup` the latest pool for `event.amm`
+//! is the right one — even across multi-hop routes that revisit the same AMM
+//! program (e.g. Raydium → Orca → Raydium).
+//!
+//! **Jupiter v4** is more fragile: its Swap log lines are processed in a
+//! second pass over `log_messages` after the walk completes, so a direct
+//! same-program swap occurring later in the same tx than a v4-routed CPI can
+//! overwrite the entry the v4 row should reference, causing misattribution.
+//! Jupiter v4 traffic is two orders of magnitude smaller than v6 and rarely
+//! interleaves with same-AMM direct activity, so this gap is documented but
+//! not yet fixed; the proper fix is per-instruction history rather than a
+//! per-program latest-wins map.
 
 use std::collections::HashMap;
 
@@ -61,12 +79,18 @@ pub(crate) mod test_fixture {
         TransactionStatusMeta,
     };
 
+    /// Fee payer placeholder — `account_keys[0]` in real Solana txs is the
+    /// fee payer, and `common::solana::get_fee_payer` reads index 0. Mirror
+    /// that here so any future test that asserts on `user` doesn't get a
+    /// program id back.
+    pub(crate) const FEE_PAYER: [u8; 32] = [0xfe; 32];
+
     pub(crate) fn make_tx(program: [u8; 32], accounts: &[[u8; 32]], data: Vec<u8>) -> ConfirmedTransaction {
-        let mut keys: Vec<Vec<u8>> = vec![program.to_vec()];
+        let mut keys: Vec<Vec<u8>> = vec![FEE_PAYER.to_vec(), program.to_vec()];
         let mut acc_idx: Vec<u8> = Vec::new();
         for (i, a) in accounts.iter().enumerate() {
             keys.push(a.to_vec());
-            acc_idx.push((i + 1) as u8);
+            acc_idx.push((i + 2) as u8); // shift past fee_payer (0) and program (1)
         }
         ConfirmedTransaction {
             transaction: Some(Transaction {
@@ -80,7 +104,7 @@ pub(crate) mod test_fixture {
                     account_keys: keys,
                     recent_blockhash: vec![0u8; 32],
                     instructions: vec![CompiledInstruction {
-                        program_id_index: 0,
+                        program_id_index: 1,
                         accounts: acc_idx,
                         data,
                     }],


### PR DESCRIPTION
## Summary

The `jupiter_v4` and `jupiter_v6` swap handlers hardcoded `amm_pool` to empty, so every Jupiter-routed swap row in `swaps` was unattributable to a specific pool. Tokens that are only ever traded via Jupiter were therefore invisible to the `/pools` endpoint that filters `amm_pool != ''`.

The Jupiter v4/v6 `Swap` event log only carries the routed AMM program; the actual pool account lives in the inner CPI's account list. This PR walks those inner CPIs as part of the existing `walk_instructions` loop, captures pool addresses keyed by program id, and looks them up when the Jupiter event fires.

Closes #171.

## Why

Reported by a customer querying `svm.dexs.getPools` for a pump.fun token only traded via Jupiter — the endpoint returned `[]` because every row had `amm_pool = ''`. The DB had ~24% of all DEX swap volume on Jupiter handlers and ~1.74% of distinct mints (millions of tokens) entirely invisible to `/pools` for the same reason.

## Changes

- **New `routed_pool::Tracker`** — records the pool address per program id for each non-Jupiter inner CPI seen in `walk_instructions`.
- **Per-AMM `extract_pool` helpers** — each per-AMM module gains a `pub(crate) fn extract_pool(ix) -> Option<Vec<u8>>` that reuses its existing decoder and returns just the pool field. Covers PumpSwap (`pumpfun_amm`), Pumpfun bonding curve, Raydium AMM v4 / CLMM / CPMM, Orca Whirlpool, Meteora DLMM, Raydium Launchpad.
- **Jupiter handlers** — `jupiter_v6::decode_instruction` and `jupiter_v4::State::handle_log` now take a `&Tracker` and look up `amm_pool` by `event.amm`.
- **Pumpfun AMM `BuyExactQuoteIn` support** — `decode_trade_instruction` now also recognises `BuyExactQuoteIn`. Jupiter routes buys through that variant; direct callers using it were also being silently dropped.
- **IDL bump** — `substreams-solana-idls` from `v1.1.2` → `v1.1.3` (adds the `BuyExactQuoteIn` enum variant the typed match relies on, see [substreams-solana-idls#117](https://github.com/pinax-network/substreams-solana-idls/pull/117)).

## Verification

- `cargo test -p dex-swaps` — 14 passing. Covers Tracker observe/lookup, per-AMM `extract_pool` for each supported program, and an end-to-end Jupiter v6 case where a pre-populated tracker produces the expected `amm_pool` on the emitted swap.
- `cargo build --target wasm32-unknown-unknown --release -p dex-swaps -p svm-dex` — clean.
- Ran the rebuilt substreams against the reporter's mainnet tx (`61heGfiqm9enY7ME...`). The Jupiter→PumpSwap row for mint `8HyG5qPSp1M5Ez8KvL67NktTyCtHvr6Xn87b2UHNpump` now carries `ammPool = "BDhLfCBNSMp58ZhYnfougeAjcHv8nHpg9gTWgBE5Z6pT"` — verified on-chain to be the real PumpSwap pool for that token.

## Not covered

Jupiter routes through several AMMs that don't have per-AMM decoders in `dex-swaps` yet (Meteora DAMM, SolFi, Heaven, Goonfi, BonkSwap, Moonshot, etc.). Those will continue to surface as Jupiter rows with empty `amm_pool` until decoders land — incremental, not a regression.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)