### PR TITLE
fix(dex-swaps): decode pump.fun events at fixed offsets

### DIFF
--- a/dex-swaps/src/pumpfun.rs
+++ b/dex-swaps/src/pumpfun.rs
@@ -16,6 +16,24 @@ struct TradeEvent {
     user: Vec<u8>,
 }
 
+// Pump.fun bonding-curve TradeEvent anchor discriminator. Stable since launch.
+const TRADE_EVENT: [u8; 8] = [189, 219, 127, 211, 78, 230, 97, 238];
+const ANCHOR_SELF_CPI_TAG: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
+
+// Stable byte offsets within the TradeEvent payload (after the 16-byte
+// preamble has been stripped). The pump.fun bonding curve TradeEvent has
+// gone through V0..V3 (and now V4-shape with `ix_name` / cashback / extra
+// volume fields, ~303-byte payload), but the leading layout — `mint` +
+// `sol_amount` + `token_amount` + `is_buy` + `user` — has been stable
+// since V0. Reading at fixed offsets and ignoring trailing bytes makes
+// the decoder resilient to future append-only schema bumps.
+const MINT_OFFSET: usize = 0;
+const SOL_AMOUNT_OFFSET: usize = 32;
+const TOKEN_AMOUNT_OFFSET: usize = 40;
+const IS_BUY_OFFSET: usize = 48;
+const USER_OFFSET: usize = 49;
+const MIN_PAYLOAD_LEN: usize = USER_OFFSET + 32; // 81 bytes
+
 pub(crate) fn handle_instruction(pending_trade: &mut Option<PendingTrade>, instruction: &InstructionView) -> Option<pb::Swap> {
     let program_id = instruction.program_id().0;
     if program_id != &pumpfun::PROGRAM_ID {
@@ -62,35 +80,134 @@ fn decode_trade_instruction(instruction: &InstructionView) -> Option<PendingTrad
 }
 
 fn decode_trade_event(instruction: &InstructionView) -> Option<TradeEvent> {
-    match pumpfun::events::unpack(instruction.data()) {
-        Ok(pumpfun::events::PumpFunEvent::TradeV0(event)) => Some(TradeEvent {
-            mint: event.mint.to_bytes().to_vec(),
-            sol_amount: event.sol_amount,
-            token_amount: event.token_amount,
-            is_buy: event.is_buy,
-            user: event.user.to_bytes().to_vec(),
-        }),
-        Ok(pumpfun::events::PumpFunEvent::TradeV1(event)) => Some(TradeEvent {
-            mint: event.mint.to_bytes().to_vec(),
-            sol_amount: event.sol_amount,
-            token_amount: event.token_amount,
-            is_buy: event.is_buy,
-            user: event.user.to_bytes().to_vec(),
-        }),
-        Ok(pumpfun::events::PumpFunEvent::TradeV2(event)) => Some(TradeEvent {
-            mint: event.mint.to_bytes().to_vec(),
-            sol_amount: event.sol_amount,
-            token_amount: event.token_amount,
-            is_buy: event.is_buy,
-            user: event.user.to_bytes().to_vec(),
-        }),
-        Ok(pumpfun::events::PumpFunEvent::TradeV3(event)) => Some(TradeEvent {
-            mint: event.mint.to_bytes().to_vec(),
-            sol_amount: event.sol_amount,
-            token_amount: event.token_amount,
-            is_buy: event.is_buy,
-            user: event.user.to_bytes().to_vec(),
-        }),
-        _ => None,
+    decode_event_payload(instruction.data())
+}
+
+fn decode_event_payload(data: &[u8]) -> Option<TradeEvent> {
+    // emit_cpi! invocation: [ANCHOR_SELF_CPI_TAG (8B)][TRADE_EVENT (8B)][payload]
+    if data.len() < 16 {
+        return None;
+    }
+    if data[..8] != ANCHOR_SELF_CPI_TAG {
+        return None;
+    }
+    let event_disc: [u8; 8] = data[8..16].try_into().ok()?;
+    if event_disc != TRADE_EVENT {
+        return None;
+    }
+    let payload = &data[16..];
+    if payload.len() < MIN_PAYLOAD_LEN {
+        return None;
+    }
+
+    let mint = payload[MINT_OFFSET..MINT_OFFSET + 32].to_vec();
+    let sol_amount = u64::from_le_bytes(payload[SOL_AMOUNT_OFFSET..SOL_AMOUNT_OFFSET + 8].try_into().ok()?);
+    let token_amount = u64::from_le_bytes(payload[TOKEN_AMOUNT_OFFSET..TOKEN_AMOUNT_OFFSET + 8].try_into().ok()?);
+    let is_buy = match payload[IS_BUY_OFFSET] {
+        0 => false,
+        1 => true,
+        _ => return None, // bool is strictly 0 or 1 in Borsh
+    };
+    let user = payload[USER_OFFSET..USER_OFFSET + 32].to_vec();
+
+    Some(TradeEvent {
+        mint,
+        sol_amount,
+        token_amount,
+        is_buy,
+        user,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_event(is_buy: bool, mint: [u8; 32], user: [u8; 32], sol: u64, token: u64, trailing: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(16 + 81 + trailing.len());
+        data.extend_from_slice(&ANCHOR_SELF_CPI_TAG);
+        data.extend_from_slice(&TRADE_EVENT);
+        data.extend_from_slice(&mint);                                      // 32
+        data.extend_from_slice(&sol.to_le_bytes());                         // 8
+        data.extend_from_slice(&token.to_le_bytes());                       // 8
+        data.push(if is_buy { 1 } else { 0 });                              // 1
+        data.extend_from_slice(&user);                                      // 32
+        data.extend_from_slice(trailing);
+        data
+    }
+
+    fn pk(b: u8) -> [u8; 32] { [b; 32] }
+
+    #[test]
+    fn decodes_buy_with_v0_payload() {
+        let data = make_event(true, pk(0xa1), pk(0xa2), 1_000_000_000, 50_000_000, &[]);
+        let ev = decode_event_payload(&data).unwrap();
+        assert!(ev.is_buy);
+        assert_eq!(ev.sol_amount, 1_000_000_000);
+        assert_eq!(ev.token_amount, 50_000_000);
+        assert_eq!(ev.mint, pk(0xa1).to_vec());
+        assert_eq!(ev.user, pk(0xa2).to_vec());
+    }
+
+    #[test]
+    fn decodes_sell_with_v0_payload() {
+        let data = make_event(false, pk(0xb1), pk(0xb2), 7, 13, &[]);
+        let ev = decode_event_payload(&data).unwrap();
+        assert!(!ev.is_buy);
+        assert_eq!(ev.sol_amount, 7);
+        assert_eq!(ev.token_amount, 13);
+    }
+
+    #[test]
+    fn ignores_trailing_v3_fields() {
+        // V3 appends timestamp + 4 reserves + fee_recipient + 2 fee fields + creator + 2 creator fees
+        // + bool track_volume + 4 volume tokens + last_update_timestamp = lots of bytes.
+        let trailing = vec![0u8; 169]; // V3 payload length minus V0 (250 - 81)
+        let data = make_event(true, pk(0xc1), pk(0xc2), 100, 200, &trailing);
+        let ev = decode_event_payload(&data).unwrap();
+        assert_eq!(ev.sol_amount, 100);
+        assert_eq!(ev.token_amount, 200);
+    }
+
+    #[test]
+    fn ignores_trailing_post_v3_fields() {
+        // Post-V3 appends ix_name (String) + cashback fields + more.
+        let trailing = vec![0u8; 250];
+        let data = make_event(true, pk(0xd1), pk(0xd2), 42, 84, &trailing);
+        let ev = decode_event_payload(&data).unwrap();
+        assert_eq!(ev.sol_amount, 42);
+        assert_eq!(ev.token_amount, 84);
+    }
+
+    #[test]
+    fn rejects_non_trade_event_disc() {
+        // Replace TRADE_EVENT with arbitrary 8 bytes.
+        let mut data = make_event(true, pk(0), pk(0), 1, 1, &[]);
+        data[8..16].copy_from_slice(&[0xff; 8]);
+        assert!(decode_event_payload(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_data_without_anchor_cpi_tag() {
+        let mut data = make_event(true, pk(0), pk(0), 1, 1, &[]);
+        data[..8].fill(0);
+        assert!(decode_event_payload(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_short_payload() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&ANCHOR_SELF_CPI_TAG);
+        data.extend_from_slice(&TRADE_EVENT);
+        data.extend_from_slice(&[0u8; 50]); // shorter than 81-byte minimum
+        assert!(decode_event_payload(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_invalid_is_buy_byte() {
+        let mut data = make_event(true, pk(0), pk(0), 1, 1, &[]);
+        // is_buy lives at offset 16 (preamble) + 48 (within payload) = 64
+        data[16 + IS_BUY_OFFSET] = 2;
+        assert!(decode_event_payload(&data).is_none());
     }
 }

--- a/dex-swaps/src/pumpfun_amm.rs
+++ b/dex-swaps/src/pumpfun_amm.rs
@@ -1,6 +1,6 @@
 use proto::pb::dex::swaps::v1 as pb;
 use substreams_solana::block_view::InstructionView;
-use substreams_solana_idls::pumpfun::amm as pumpfun_amm;
+use substreams_solana_idls::pumpswap;
 
 pub(crate) struct PendingTrade {
     pool: Vec<u8>,
@@ -15,9 +15,31 @@ struct TradeEvent {
     quote_amount: u64,
 }
 
+// PumpSwap event discriminators (Anchor anchor_disc).
+// Stable since the original Pump.fun AMM program — the program has only ever
+// extended the payload, never changed these tags.
+const BUY_EVENT: [u8; 8] = [103, 244, 82, 31, 44, 245, 119, 119];
+const SELL_EVENT: [u8; 8] = [62, 47, 55, 10, 165, 3, 220, 42];
+
+// Anchor self-CPI invocation tag — prepended to events emitted via `emit_cpi!`.
+const ANCHOR_SELF_CPI_TAG: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
+
+// Stable byte offsets within the BuyEvent / SellEvent payload (after the
+// anchor_disc has been stripped). The pump.fun AMM program has appended
+// fields to these events at least three times since launch
+// (BuyEventV1 → BuyEventV2 → PumpSwap with track_volume / cashback / ix_name),
+// but the leading layout — `i64 timestamp` + 13×`u64` + 7×`pubkey` — has
+// never been reordered or shrunk. We read the fields we need at fixed
+// offsets and ignore everything that follows, which makes the decoder
+// resilient to future program upgrades that append more fields.
+const BASE_AMOUNT_OFFSET: usize = 8;        // 2nd field — `base_amount_(in|out)`
+const QUOTE_AMOUNT_OFFSET: usize = 56;      // 8th field — `quote_amount_(in|out)`
+const USER_OFFSET: usize = 144;             // 16th field — 2nd pubkey
+const MIN_PAYLOAD_LEN: usize = USER_OFFSET + 32; // 176 bytes
+
 pub(crate) fn handle_instruction(pending_trade: &mut Option<PendingTrade>, instruction: &InstructionView) -> Option<pb::Swap> {
     let program_id = instruction.program_id().0;
-    if program_id != &pumpfun_amm::PROGRAM_ID {
+    if program_id != &pumpswap::PROGRAM_ID {
         return None;
     }
 
@@ -36,9 +58,9 @@ pub(crate) fn handle_instruction(pending_trade: &mut Option<PendingTrade>, instr
 
     Some(pb::Swap {
         protocol: pb::Protocol::PumpfunAmm as i32,
-        program_id: pumpfun_amm::PROGRAM_ID.to_vec(),
+        program_id: pumpswap::PROGRAM_ID.to_vec(),
         stack_height: instruction.stack_height(),
-        amm: pumpfun_amm::PROGRAM_ID.to_vec(),
+        amm: pumpswap::PROGRAM_ID.to_vec(),
         amm_pool: trade.pool,
         user: event.user,
         input_mint: if event.is_buy { trade.quote_mint.clone() } else { trade.base_mint.clone() },
@@ -49,17 +71,20 @@ pub(crate) fn handle_instruction(pending_trade: &mut Option<PendingTrade>, instr
 }
 
 pub(crate) fn extract_pool(instruction: &InstructionView) -> Option<Vec<u8>> {
-    if instruction.program_id().0 != &pumpfun_amm::PROGRAM_ID {
+    if instruction.program_id().0 != &pumpswap::PROGRAM_ID {
         return None;
     }
     decode_trade_instruction(instruction).map(|t| t.pool)
 }
 
 fn decode_trade_instruction(instruction: &InstructionView) -> Option<PendingTrade> {
-    match pumpfun_amm::instructions::unpack(instruction.data()) {
-        Ok(pumpfun_amm::instructions::PumpFunAmmInstruction::Buy(_))
-        | Ok(pumpfun_amm::instructions::PumpFunAmmInstruction::BuyExactQuoteIn(_))
-        | Ok(pumpfun_amm::instructions::PumpFunAmmInstruction::Sell(_)) => Some(PendingTrade {
+    // Instruction discriminators (BUY / SELL / BUY_EXACT_QUOTE_IN) and the
+    // first 17 accounts are unchanged across the legacy `pumpfun::amm` IDL
+    // and the newer `pumpswap` IDL.
+    match pumpswap::instructions::unpack(instruction.data()) {
+        Ok(pumpswap::instructions::PumpSwapInstruction::Buy(_))
+        | Ok(pumpswap::instructions::PumpSwapInstruction::BuyExactQuoteIn(_))
+        | Ok(pumpswap::instructions::PumpSwapInstruction::Sell(_)) => Some(PendingTrade {
             pool: instruction.accounts().get(0)?.0.to_vec(),
             base_mint: instruction.accounts().get(4)?.0.to_vec(),
             quote_mint: instruction.accounts().get(5)?.0.to_vec(),
@@ -69,31 +94,151 @@ fn decode_trade_instruction(instruction: &InstructionView) -> Option<PendingTrad
 }
 
 fn decode_trade_event(instruction: &InstructionView) -> Option<TradeEvent> {
-    match pumpfun_amm::events::unpack(instruction.data()) {
-        Ok(pumpfun_amm::events::PumpFunAmmEvent::BuyEventV1(event)) => Some(TradeEvent {
-            is_buy: true,
-            user: event.user.to_bytes().to_vec(),
-            base_amount: event.base_amount_out,
-            quote_amount: event.quote_amount_in,
-        }),
-        Ok(pumpfun_amm::events::PumpFunAmmEvent::BuyEventV2(event)) => Some(TradeEvent {
-            is_buy: true,
-            user: event.user.to_bytes().to_vec(),
-            base_amount: event.base_amount_out,
-            quote_amount: event.quote_amount_in,
-        }),
-        Ok(pumpfun_amm::events::PumpFunAmmEvent::SellEventV1(event)) => Some(TradeEvent {
-            is_buy: false,
-            user: event.user.to_bytes().to_vec(),
-            base_amount: event.base_amount_in,
-            quote_amount: event.quote_amount_out,
-        }),
-        Ok(pumpfun_amm::events::PumpFunAmmEvent::SellEventV2(event)) => Some(TradeEvent {
-            is_buy: false,
-            user: event.user.to_bytes().to_vec(),
-            base_amount: event.base_amount_in,
-            quote_amount: event.quote_amount_out,
-        }),
-        _ => None,
+    decode_event_payload(instruction.data())
+}
+
+fn decode_event_payload(data: &[u8]) -> Option<TradeEvent> {
+    // Events are emitted via `emit_cpi!`, so the instruction data is laid out
+    // as `[ANCHOR_SELF_CPI_TAG (8B)][event_disc (8B)][borsh-serialized event]`.
+    // Strip both prefixes and decode the payload at fixed offsets.
+    if data.len() < 16 {
+        return None;
+    }
+    if data[..8] != ANCHOR_SELF_CPI_TAG {
+        return None;
+    }
+    let event_disc: [u8; 8] = data[8..16].try_into().ok()?;
+    let payload = &data[16..];
+
+    let is_buy = match event_disc {
+        BUY_EVENT => true,
+        SELL_EVENT => false,
+        _ => return None,
+    };
+
+    if payload.len() < MIN_PAYLOAD_LEN {
+        return None;
+    }
+
+    let base_amount = u64::from_le_bytes(payload[BASE_AMOUNT_OFFSET..BASE_AMOUNT_OFFSET + 8].try_into().ok()?);
+    let quote_amount = u64::from_le_bytes(payload[QUOTE_AMOUNT_OFFSET..QUOTE_AMOUNT_OFFSET + 8].try_into().ok()?);
+    let user = payload[USER_OFFSET..USER_OFFSET + 32].to_vec();
+
+    Some(TradeEvent {
+        is_buy,
+        user,
+        base_amount,
+        quote_amount,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic CPI event payload: anchor tag + event disc + leading layout.
+    /// Trailing bytes simulate program upgrades appending fields.
+    fn make_event(disc: [u8; 8], base: u64, quote: u64, user: [u8; 32], trailing: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(16 + 176 + trailing.len());
+        data.extend_from_slice(&ANCHOR_SELF_CPI_TAG);
+        data.extend_from_slice(&disc);
+        // payload (176 bytes for the stable leading layout)
+        data.extend_from_slice(&0i64.to_le_bytes());                   // timestamp
+        data.extend_from_slice(&base.to_le_bytes());                   // 2nd field
+        for _ in 0..5 { data.extend_from_slice(&0u64.to_le_bytes()); } // 3rd-7th fields
+        data.extend_from_slice(&quote.to_le_bytes());                  // 8th field
+        for _ in 0..6 { data.extend_from_slice(&0u64.to_le_bytes()); } // 9th-14th fields
+        data.extend_from_slice(&[0u8; 32]);                            // pool (1st pubkey)
+        data.extend_from_slice(&user);                                 // user (2nd pubkey)
+        data.extend_from_slice(trailing);
+        data
+    }
+
+    fn user_pk(byte: u8) -> [u8; 32] { [byte; 32] }
+
+    #[test]
+    fn decodes_buy_event_minimal_payload() {
+        let data = make_event(BUY_EVENT, 1_000, 999, user_pk(0xab), &[]);
+        let ev = decode_event_payload(&data).unwrap();
+        assert!(ev.is_buy);
+        assert_eq!(ev.base_amount, 1_000);
+        assert_eq!(ev.quote_amount, 999);
+        assert_eq!(ev.user, user_pk(0xab).to_vec());
+    }
+
+    #[test]
+    fn decodes_sell_event_minimal_payload() {
+        let data = make_event(SELL_EVENT, 7, 13, user_pk(0xcd), &[]);
+        let ev = decode_event_payload(&data).unwrap();
+        assert!(!ev.is_buy);
+        assert_eq!(ev.base_amount, 7);
+        assert_eq!(ev.quote_amount, 13);
+    }
+
+    #[test]
+    fn ignores_trailing_bytes_v2_layout() {
+        // V2 appended coin_creator (32) + 2 u64 fees = 48 bytes after the leading 176.
+        let trailing = vec![0u8; 48];
+        let data = make_event(BUY_EVENT, 100, 50, user_pk(0x01), &trailing);
+        let ev = decode_event_payload(&data).unwrap();
+        assert_eq!(ev.base_amount, 100);
+        assert_eq!(ev.quote_amount, 50);
+    }
+
+    #[test]
+    fn ignores_trailing_bytes_pumpswap_layout() {
+        // PumpSwap (post-2026-02-12) appended bool + 5 u64 + string + 2 u64 cashback.
+        // The exact size doesn't matter — decoder ignores whatever follows the leading 176.
+        let trailing = vec![0u8; 224];
+        let data = make_event(BUY_EVENT, 42, 84, user_pk(0x02), &trailing);
+        let ev = decode_event_payload(&data).unwrap();
+        assert_eq!(ev.base_amount, 42);
+        assert_eq!(ev.quote_amount, 84);
+    }
+
+    #[test]
+    fn rejects_data_without_anchor_cpi_tag() {
+        // Same shape, but the leading 8 bytes are not the anchor self-CPI tag.
+        let mut data = make_event(BUY_EVENT, 1, 1, user_pk(0xff), &[]);
+        data[..8].copy_from_slice(&[0u8; 8]);
+        assert!(decode_event_payload(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_event_discriminator() {
+        let unknown_disc = [0xaa; 8];
+        let data = make_event(unknown_disc, 1, 1, user_pk(0xff), &[]);
+        assert!(decode_event_payload(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_payload_shorter_than_leading_layout() {
+        // Only 100 bytes of payload — short of the 176-byte minimum.
+        let mut data = Vec::new();
+        data.extend_from_slice(&ANCHOR_SELF_CPI_TAG);
+        data.extend_from_slice(&BUY_EVENT);
+        data.extend_from_slice(&vec![0u8; 100]);
+        assert!(decode_event_payload(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_data_too_short_for_any_disc() {
+        assert!(decode_event_payload(&[]).is_none());
+        assert!(decode_event_payload(&ANCHOR_SELF_CPI_TAG).is_none()); // only the tag
+    }
+
+    #[test]
+    fn buy_and_sell_use_same_offsets_with_inverted_meaning() {
+        // For a Buy event: 2nd field = base_amount_OUT, 8th field = quote_amount_IN.
+        // For a Sell event: 2nd field = base_amount_IN, 8th field = quote_amount_OUT.
+        // The decoder simply reports them as `base_amount` / `quote_amount`; the caller
+        // inverts based on `is_buy`. Verify both directions extract the same numerical
+        // values from the same byte positions.
+        let buy = decode_event_payload(&make_event(BUY_EVENT, 1_000, 9, user_pk(0x10), &[])).unwrap();
+        let sell = decode_event_payload(&make_event(SELL_EVENT, 1_000, 9, user_pk(0x11), &[])).unwrap();
+        assert_eq!(buy.base_amount, sell.base_amount);
+        assert_eq!(buy.quote_amount, sell.quote_amount);
+        assert!(buy.is_buy);
+        assert!(!sell.is_buy);
     }
 }


### PR DESCRIPTION
## Summary

- Switch `pumpfun_amm` and `pumpfun` (bonding curve) decoders to fixed-offset event reads so they stop breaking every time pump.fun appends fields to `BuyEvent` / `SellEvent` / `TradeEvent`.
- Adds 17 unit tests covering V0 / Vn / unknown disc / short payload / invalid bool / missing anchor self-CPI tag.
- Closes #197.

## Why

Both decoders previously dispatched event payloads through `substreams_solana_idls::*::events::unpack`, which strict-decodes via Borsh `try_from_slice`. Borsh rejects payloads with unread trailing bytes, so every time the on-chain program adds a field, ingestion stops cliff-style:

- **AMM** stopped at block `399821384` (`2026-02-12 18:46:03 UTC`). Cashback fields were added five days later in the [official IDL](https://github.com/pump-fun/pump-public-docs/commit/82dacac); volume accumulator + coin_creator had already drifted before that.
- **Bonding curve** stopped at block `373986960` (`2025-10-17 14:46:39 UTC`). TradeEvent grew past V3 — current on-chain payload is ~303 bytes vs the IDL's hardcoded `TRADE_LEN_V0..V3` of 105 / 121 / 217 / 250.

Updating the IDL once would only buy time until the next program upgrade. The new decoders read the fields we surface (`pool` / `user` / `base_amount` / `quote_amount` for the AMM; `mint` / `sol_amount` / `token_amount` / `is_buy` / `user` for the bonding curve) at stable byte offsets and ignore everything that follows. Every pump.fun event upgrade so far has been append-only on these fields, so the decoder is robust to future bumps.

Instruction-side dispatch is unchanged — `BUY` / `SELL` / `BUY_EXACT_QUOTE_IN` discriminators and the first 17 accounts have been stable across the IDL versions, so we still go through `pumpswap::instructions::unpack` for the AMM and `pumpfun::instructions::unpack` for the bonding curve.

## Verification

Live against `solana.substreams.pinax.network`:

| slot | decoder | unpatched | patched |
| --- | --- | --- | --- |
| `417997749` (single recent slot) | `pumpfun_amm` | 0 | 50 |
| `417997744`–`417997755` (11 slots) | `pumpfun_amm` | 0 | 447 swaps across 187 distinct pools |
| `418008778` (current slot) | `pumpfun` (bonding curve) | 0 | 10 |

All unit tests pass:

```
test result: ok. 27 passed; 0 failed; 0 ignored
```

## Test plan

- [x] `cargo test --target x86_64-unknown-linux-gnu` — all 27 tests pass (17 new + 10 pre-existing).
- [x] `cargo build --target wasm32-unknown-unknown --release` — clean.
- [x] `substreams pack` — packages cleanly, ~1.78 MB.
- [x] Live stream of recent slots against the prod substreams endpoint — both protocols decode where the unpatched build emits zero swaps.
- [ ] After merge: backfill from a slot a bit before the cutoff to absorb any reorg / skipped-slot weirdness.
  - pump.fun AMM: backfill from `~399820000` (cutoff was block `399821384`, `2026-02-12 18:46:03 UTC`).
  - pump.fun bonding curve: backfill from `~373985000` (cutoff was block `373986960`, `2025-10-17 14:46:39 UTC`).

## Out of scope

`darklake` (the third protocol called out on #197) — investigated, no decoder bug. The 2026-02-06 cutoff is the last actual on-chain swap; recent darklake activity is all liquidity ops, no swaps. Existing decoder is fine.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
