### PR TITLE
fix(dex-swaps): correct mint resolution for pumpfun_amm, raydium_amm_v4, orca_whirlpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,8 +3048,8 @@ dependencies = [
 
 [[package]]
 name = "substreams-solana-idls"
-version = "1.1.6"
-source = "git+https://github.com/pinax-network/substreams-solana-idls?tag=v1.1.6#e87f4bc3742e868c2145c92e4aaf6c4165cf587a"
+version = "1.2.0"
+source = "git+https://github.com/pinax-network/substreams-solana-idls?branch=feat%2Fsvm-dex-canonical-account-helpers-v1.2.0#91b63309e4aba5eae31fbdfd7a564715fa6ef70f"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "substreams-solana-idls"
 version = "1.2.0"
-source = "git+https://github.com/pinax-network/substreams-solana-idls?rev=746e9e35233a839e47969fa963cfa052eab87a86#746e9e35233a839e47969fa963cfa052eab87a86"
+source = "git+https://github.com/pinax-network/substreams-solana-idls?tag=v1.2.0#d469d1630a76b202f3dd080fdb328675fbfc61f0"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "substreams-solana-idls"
 version = "1.2.0"
-source = "git+https://github.com/pinax-network/substreams-solana-idls?branch=feat%2Fsvm-dex-canonical-account-helpers-v1.2.0#91b63309e4aba5eae31fbdfd7a564715fa6ef70f"
+source = "git+https://github.com/pinax-network/substreams-solana-idls?rev=746e9e35233a839e47969fa963cfa052eab87a86#746e9e35233a839e47969fa963cfa052eab87a86"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,10 @@ bs58 = "0.5.1"
 substreams = "0.7.3"
 substreams-abis = "0.7.12"
 substreams-solana = "0.14.2"
-substreams-solana-idls = { git = "https://github.com/pinax-network/substreams-solana-idls", branch = "feat/svm-dex-canonical-account-helpers-v1.2.0" }
+# Pinned to the v1.2.0 candidate commit on branch
+# `feat/svm-dex-canonical-account-helpers-v1.2.0`. Flip back to a `tag = "v1.2.0"`
+# pin once the IDL crate PR lands and tags the release.
+substreams-solana-idls = { git = "https://github.com/pinax-network/substreams-solana-idls", rev = "746e9e35233a839e47969fa963cfa052eab87a86" }
 spl-token = "9.0.0"
 substreams-solana-program-instructions = "0.3"
 substreams-database-change = "4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,10 +85,7 @@ bs58 = "0.5.1"
 substreams = "0.7.3"
 substreams-abis = "0.7.12"
 substreams-solana = "0.14.2"
-# Pinned to the v1.2.0 candidate commit on branch
-# `feat/svm-dex-canonical-account-helpers-v1.2.0`. Flip back to a `tag = "v1.2.0"`
-# pin once the IDL crate PR lands and tags the release.
-substreams-solana-idls = { git = "https://github.com/pinax-network/substreams-solana-idls", rev = "746e9e35233a839e47969fa963cfa052eab87a86" }
+substreams-solana-idls = { git = "https://github.com/pinax-network/substreams-solana-idls", tag = "v1.2.0" }
 spl-token = "9.0.0"
 substreams-solana-program-instructions = "0.3"
 substreams-database-change = "4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ bs58 = "0.5.1"
 substreams = "0.7.3"
 substreams-abis = "0.7.12"
 substreams-solana = "0.14.2"
-substreams-solana-idls = { git = "https://github.com/pinax-network/substreams-solana-idls", tag = "v1.1.6" }
+substreams-solana-idls = { git = "https://github.com/pinax-network/substreams-solana-idls", branch = "feat/svm-dex-canonical-account-helpers-v1.2.0" }
 spl-token = "9.0.0"
 substreams-solana-program-instructions = "0.3"
 substreams-database-change = "4.0.0"

--- a/dex-swaps/src/lib.rs
+++ b/dex-swaps/src/lib.rs
@@ -91,10 +91,10 @@ fn process_transaction(tx: ConfirmedTransaction) -> Option<pb::Transaction> {
             swaps.push(swap);
         }
 
-        raydium_amm_v4_state.handle_instruction(&instruction);
+        raydium_amm_v4_state.handle_instruction(&instruction, &token_mints);
         raydium_clmm_state.handle_instruction(&instruction, &token_mints);
         raydium_cpmm_state.handle_instruction(&instruction);
-        orca_whirlpool_state.handle_instruction(&instruction);
+        orca_whirlpool_state.handle_instruction(&instruction, &token_mints);
 
         if let Some(swap) = spl_token_swap::handle_instruction(&instruction, &token_mints) {
             log::info!("SPL Token Swap 🚨 {}", base58::encode(&swap.program_id));

--- a/dex-swaps/src/orca_whirlpool.rs
+++ b/dex-swaps/src/orca_whirlpool.rs
@@ -4,6 +4,7 @@ use substreams_solana::block_view::InstructionView;
 use substreams_solana_idls::orca;
 
 use crate::logs::{scoped_program_log, ProgramLog};
+use crate::token_mints::TokenMintLookup;
 
 pub(crate) struct State {
     pending: Vec<InstructionSwap>,
@@ -20,8 +21,8 @@ impl State {
         }
     }
 
-    pub(crate) fn handle_instruction(&mut self, ix: &InstructionView) {
-        if let Some(swap) = decode_instruction(ix) {
+    pub(crate) fn handle_instruction(&mut self, ix: &InstructionView, token_mints: &TokenMintLookup) {
+        if let Some(swap) = decode_instruction(ix, Some(token_mints)) {
             self.pending.push(swap);
         }
     }
@@ -37,11 +38,15 @@ impl State {
         let instruction = self.pending.get(self.next_index)?;
         self.next_index += 1;
 
-        let (input_mint, output_mint) = if instruction.a_to_b {
-            (instruction.mint_a.clone(), instruction.mint_b.clone())
-        } else {
-            (instruction.mint_b.clone(), instruction.mint_a.clone())
-        };
+        // Legacy `Swap` only exposes `token_vault_a` / `token_vault_b` in its
+        // accounts list; mints had to be resolved via `TokenMintLookup` in
+        // `handle_instruction`. If that lookup missed, skip emitting this
+        // row (we still consumed `next_index` so subsequent swaps stay
+        // aligned with their logs).
+        let mint_a = instruction.mint_a.clone()?;
+        let mint_b = instruction.mint_b.clone()?;
+
+        let (input_mint, output_mint) = if instruction.a_to_b { (mint_a, mint_b) } else { (mint_b, mint_a) };
 
         Some(pb::Swap {
             protocol: pb::Protocol::OrcaWhirlpool as i32,
@@ -58,12 +63,17 @@ impl State {
     }
 }
 
+#[cfg_attr(test, derive(Clone))]
 struct InstructionSwap {
     stack_height: u32,
     user: Vec<u8>,
     whirlpool: Vec<u8>,
-    mint_a: Vec<u8>,
-    mint_b: Vec<u8>,
+    /// Mint resolved from `token_vault_a` (legacy) or read from
+    /// `token_mint_a` directly (V2). `None` only when the legacy `Swap`
+    /// variant could not resolve the vault via `TokenMintLookup`.
+    mint_a: Option<Vec<u8>>,
+    /// See `mint_a`.
+    mint_b: Option<Vec<u8>>,
     a_to_b: bool,
 }
 
@@ -73,10 +83,12 @@ struct LogSwap {
 }
 
 pub(crate) fn extract_pool(ix: &InstructionView) -> Option<Vec<u8>> {
-    decode_instruction(ix).map(|s| s.whirlpool)
+    // `routed_pool::Tracker::observe` only needs the pool address; mints are
+    // resolved later in `handle_instruction` when `TokenMintLookup` is in scope.
+    decode_instruction(ix, None).map(|s| s.whirlpool)
 }
 
-fn decode_instruction(ix: &InstructionView) -> Option<InstructionSwap> {
+fn decode_instruction(ix: &InstructionView, token_mints: Option<&TokenMintLookup>) -> Option<InstructionSwap> {
     let program_id = ix.program_id().0;
     if program_id != &orca::whirlpool::PROGRAM_ID {
         return None;
@@ -84,24 +96,40 @@ fn decode_instruction(ix: &InstructionView) -> Option<InstructionSwap> {
 
     match orca::whirlpool::instructions::unpack(ix.data()) {
         Ok(orca::whirlpool::instructions::WhirlpoolInstruction::Swap(event)) => {
-            let accounts = orca::whirlpool::accounts::get_swap_accounts(&ix).ok()?;
+            // Legacy `swap` only carries vaults — `token_vault_a` and
+            // `token_vault_b` — in its account list. Pre-fix this adapter
+            // wrote those vault addresses straight into the `mint_a`/`mint_b`
+            // slots, leaking pool token accounts into the protobuf's mint
+            // fields. Resolve via `TokenMintLookup`; emit `None` placeholders
+            // when the lookup misses so `handle_log` skips the row but stays
+            // sequentially aligned.
+            let accounts = orca::whirlpool::accounts::get_swap_accounts(ix).ok()?;
+            let (mint_a, mint_b) = match token_mints {
+                Some(lookup) => (
+                    lookup.mint_for(accounts.token_vault_a.to_bytes().as_ref()),
+                    lookup.mint_for(accounts.token_vault_b.to_bytes().as_ref()),
+                ),
+                None => (None, None),
+            };
             Some(InstructionSwap {
                 stack_height: ix.stack_height(),
                 user: accounts.token_authority.to_bytes().to_vec(),
                 whirlpool: accounts.whirlpool.to_bytes().to_vec(),
-                mint_a: accounts.token_vault_a.to_bytes().to_vec(),
-                mint_b: accounts.token_vault_b.to_bytes().to_vec(),
+                mint_a,
+                mint_b,
                 a_to_b: event.a_to_b,
             })
         }
         Ok(orca::whirlpool::instructions::WhirlpoolInstruction::SwapV2(event)) => {
-            let accounts = orca::whirlpool::accounts::get_swap_v2_accounts(&ix).ok()?;
+            // SwapV2 exposes mint accounts directly — no vault→mint resolution
+            // step needed.
+            let accounts = orca::whirlpool::accounts::get_swap_v2_accounts(ix).ok()?;
             Some(InstructionSwap {
                 stack_height: ix.stack_height(),
                 user: accounts.token_authority.to_bytes().to_vec(),
                 whirlpool: accounts.whirlpool.to_bytes().to_vec(),
-                mint_a: accounts.token_mint_a.to_bytes().to_vec(),
-                mint_b: accounts.token_mint_b.to_bytes().to_vec(),
+                mint_a: Some(accounts.token_mint_a.to_bytes().to_vec()),
+                mint_b: Some(accounts.token_mint_b.to_bytes().to_vec()),
                 a_to_b: event.a_to_b,
             })
         }
@@ -117,5 +145,144 @@ fn parse_log_data(log_message: &str) -> Option<LogSwap> {
             output_amount: event.output_amount,
         }),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use substreams_solana::base58;
+    use substreams_solana::pb::sf::solana::r#type::v1::{
+        CompiledInstruction, ConfirmedTransaction, Message, MessageHeader, TokenBalance, Transaction,
+        TransactionStatusMeta, UiTokenAmount,
+    };
+
+    /// Whirlpool `swap` discriminator from the IDL.
+    const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+    /// SwapInstruction args body — values irrelevant for these tests.
+    fn swap_body(a_to_b: bool) -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend_from_slice(&0u64.to_le_bytes()); // amount
+        b.extend_from_slice(&0u64.to_le_bytes()); // other_amount_threshold
+        b.extend_from_slice(&0u128.to_le_bytes()); // sqrt_price_limit
+        b.push(0u8); // amount_specified_is_input
+        b.push(if a_to_b { 1 } else { 0 });
+        b
+    }
+
+    fn make_tx(accounts: &[[u8; 32]], token_balances: &[(u32, [u8; 32])]) -> ConfirmedTransaction {
+        let fee_payer = [0xfe; 32];
+        let program = orca::whirlpool::PROGRAM_ID;
+        let mut keys: Vec<Vec<u8>> = vec![fee_payer.to_vec(), program.to_vec()];
+        let mut acc_idx: Vec<u8> = Vec::new();
+        for (i, a) in accounts.iter().enumerate() {
+            keys.push(a.to_vec());
+            acc_idx.push((i + 2) as u8);
+        }
+        let mut data = SWAP_DISC.to_vec();
+        data.extend_from_slice(&swap_body(true));
+
+        let pre_token_balances = token_balances
+            .iter()
+            .map(|(idx, mint)| TokenBalance {
+                account_index: *idx,
+                mint: base58::encode(mint),
+                owner: "".to_string(),
+                program_id: "".to_string(),
+                ui_token_amount: Some(UiTokenAmount::default()),
+            })
+            .collect();
+
+        ConfirmedTransaction {
+            transaction: Some(Transaction {
+                signatures: vec![vec![0u8; 64]],
+                message: Some(Message {
+                    header: Some(MessageHeader {
+                        num_required_signatures: 1,
+                        num_readonly_signed_accounts: 0,
+                        num_readonly_unsigned_accounts: 0,
+                    }),
+                    account_keys: keys,
+                    recent_blockhash: vec![0u8; 32],
+                    instructions: vec![CompiledInstruction {
+                        program_id_index: 1,
+                        accounts: acc_idx,
+                        data,
+                    }],
+                    versioned: false,
+                    address_table_lookups: vec![],
+                }),
+            }),
+            meta: Some(TransactionStatusMeta {
+                pre_token_balances,
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[test]
+    fn legacy_swap_resolves_vaults_to_mints() {
+        // SwapAccounts layout: token_program, token_authority, whirlpool,
+        // token_owner_account_a, token_vault_a, token_owner_account_b,
+        // token_vault_b, tick_array0, tick_array1, tick_array2, oracle.
+        let token_program = [0x00; 32];
+        let token_authority = [0x01; 32];
+        let whirlpool = [0x02; 32];
+        let owner_a = [0x03; 32];
+        let vault_a = [0x04; 32];
+        let owner_b = [0x05; 32];
+        let vault_b = [0x06; 32];
+        let tick0 = [0x07; 32];
+        let tick1 = [0x08; 32];
+        let tick2 = [0x09; 32];
+        let oracle = [0x0a; 32];
+
+        let mint_a = [0xaa; 32];
+        let mint_b = [0xbb; 32];
+        // vault_a sits at account_keys[4 + 2] = 6, vault_b at [6 + 2] = 8.
+        let token_balances: &[(u32, [u8; 32])] = &[(6, mint_a), (8, mint_b)];
+
+        let tx = make_tx(
+            &[
+                token_program,
+                token_authority,
+                whirlpool,
+                owner_a,
+                vault_a,
+                owner_b,
+                vault_b,
+                tick0,
+                tick1,
+                tick2,
+                oracle,
+            ],
+            token_balances,
+        );
+        let meta = tx.meta.as_ref().unwrap();
+        let mints = TokenMintLookup::new(&tx, meta);
+        let ix = tx.walk_instructions().next().unwrap();
+
+        let swap = decode_instruction(&ix, Some(&mints)).expect("legacy swap must decode");
+        assert_eq!(swap.mint_a.as_deref(), Some(mint_a.as_slice()), "mint_a must be resolved mint, not vault");
+        assert_eq!(swap.mint_b.as_deref(), Some(mint_b.as_slice()), "mint_b must be resolved mint, not vault");
+        assert_eq!(swap.whirlpool, whirlpool.to_vec());
+
+        // Regression: vault address must NOT leak into the mint slot.
+        assert_ne!(swap.mint_a.as_deref(), Some(vault_a.as_slice()));
+        assert_ne!(swap.mint_b.as_deref(), Some(vault_b.as_slice()));
+    }
+
+    #[test]
+    fn legacy_swap_unresolved_lookup_keeps_placeholder_with_none() {
+        let accounts: Vec<[u8; 32]> = (0u8..11u8).map(|i| [i + 1; 32]).collect();
+        let tx = make_tx(&accounts, &[]);
+        let meta = tx.meta.as_ref().unwrap();
+        let mints = TokenMintLookup::new(&tx, meta);
+        let ix = tx.walk_instructions().next().unwrap();
+
+        let swap = decode_instruction(&ix, Some(&mints)).expect("placeholder must still emit");
+        assert!(swap.mint_a.is_none(), "vault must not leak when lookup misses");
+        assert!(swap.mint_b.is_none(), "vault must not leak when lookup misses");
     }
 }

--- a/dex-swaps/src/pumpfun_amm.rs
+++ b/dex-swaps/src/pumpfun_amm.rs
@@ -1,6 +1,7 @@
 use proto::pb::dex::swaps::v1 as pb;
 use substreams_solana::block_view::InstructionView;
 use substreams_solana_idls::pumpswap;
+use substreams_solana_idls::pumpswap::accounts::TradeAccounts;
 use substreams_solana_idls::pumpswap::events::TradeDirection;
 
 pub(crate) struct PendingTrade {
@@ -52,18 +53,177 @@ pub(crate) fn extract_pool(instruction: &InstructionView) -> Option<Vec<u8>> {
     if instruction.program_id().0 != &pumpswap::PROGRAM_ID {
         return None;
     }
-    decode_trade_instruction(instruction).map(|t| t.pool)
+    // `routed_pool::Tracker::observe` only needs the pool address (accounts[0])
+    // for cross-protocol routing attribution. We deliberately don't run the
+    // full strict `TradeAccounts::try_from` here — pre-filter inner CPI
+    // fixtures may carry only the pool slot, and the strict path would reject
+    // them with `Missing` for trailing accounts.
+    if !is_trade_instruction(instruction) {
+        return None;
+    }
+    instruction.accounts().get(0).map(|a| a.0.to_vec())
+}
+
+fn is_trade_instruction(instruction: &InstructionView) -> bool {
+    matches!(
+        pumpswap::instructions::unpack(instruction.data()),
+        Ok(pumpswap::instructions::PumpSwapInstruction::Buy(_))
+            | Ok(pumpswap::instructions::PumpSwapInstruction::BuyExactQuoteIn(_))
+            | Ok(pumpswap::instructions::PumpSwapInstruction::Sell(_))
+    )
 }
 
 fn decode_trade_instruction(instruction: &InstructionView) -> Option<PendingTrade> {
     match pumpswap::instructions::unpack(instruction.data()) {
         Ok(pumpswap::instructions::PumpSwapInstruction::Buy(_))
         | Ok(pumpswap::instructions::PumpSwapInstruction::BuyExactQuoteIn(_))
-        | Ok(pumpswap::instructions::PumpSwapInstruction::Sell(_)) => Some(PendingTrade {
-            pool: instruction.accounts().get(0)?.0.to_vec(),
-            base_mint: instruction.accounts().get(4)?.0.to_vec(),
-            quote_mint: instruction.accounts().get(5)?.0.to_vec(),
-        }),
+        | Ok(pumpswap::instructions::PumpSwapInstruction::Sell(_)) => {
+            // IDL-canonical account layout — see the comment + IDX_* constants
+            // in `substreams_solana_idls::pumpswap::accounts`. Hand-indexing
+            // `accounts.get(N)` here previously caused an off-by-one
+            // (`base_mint` = accounts[4], should have been [3]) which let the
+            // user's *base token account* leak into the `mint` slot,
+            // producing a long tail of fake `(mint0, mint1)` pairs per pool
+            // downstream.
+            let accounts = TradeAccounts::try_from(instruction).ok()?;
+            Some(PendingTrade {
+                pool: accounts.pool.to_bytes().to_vec(),
+                base_mint: accounts.base_mint.to_bytes().to_vec(),
+                quote_mint: accounts.quote_mint.to_bytes().to_vec(),
+            })
+        }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use substreams_solana::pb::sf::solana::r#type::v1::{
+        CompiledInstruction, ConfirmedTransaction, Message, MessageHeader, Transaction, TransactionStatusMeta,
+    };
+
+    /// PumpSwap `buy` instruction discriminator from `pumpswap/idl.json`.
+    const BUY_DISC: [u8; 8] = [102, 6, 61, 18, 1, 218, 235, 234];
+    /// PumpSwap `sell` instruction discriminator.
+    const SELL_DISC: [u8; 8] = [51, 230, 133, 164, 1, 127, 131, 173];
+
+    fn buy_body() -> Vec<u8> {
+        // BuyInstruction { base_amount_out: u64, max_quote_amount_in: u64 }
+        let mut b = Vec::new();
+        b.extend_from_slice(&0u64.to_le_bytes());
+        b.extend_from_slice(&0u64.to_le_bytes());
+        b
+    }
+
+    fn sell_body() -> Vec<u8> {
+        // SellInstruction { base_amount_in: u64, min_quote_amount_out: u64 }
+        let mut b = Vec::new();
+        b.extend_from_slice(&0u64.to_le_bytes());
+        b.extend_from_slice(&0u64.to_le_bytes());
+        b
+    }
+
+    /// Build a ConfirmedTransaction with one PumpSwap instruction.
+    fn make_tx(disc: [u8; 8], body: Vec<u8>, accounts: &[[u8; 32]]) -> ConfirmedTransaction {
+        let fee_payer = [0xfe; 32];
+        let program = pumpswap::PROGRAM_ID;
+        let mut keys: Vec<Vec<u8>> = vec![fee_payer.to_vec(), program.to_vec()];
+        let mut acc_idx: Vec<u8> = Vec::new();
+        for (i, a) in accounts.iter().enumerate() {
+            keys.push(a.to_vec());
+            acc_idx.push((i + 2) as u8);
+        }
+        let mut data = disc.to_vec();
+        data.extend_from_slice(&body);
+
+        ConfirmedTransaction {
+            transaction: Some(Transaction {
+                signatures: vec![vec![0u8; 64]],
+                message: Some(Message {
+                    header: Some(MessageHeader {
+                        num_required_signatures: 1,
+                        num_readonly_signed_accounts: 0,
+                        num_readonly_unsigned_accounts: 0,
+                    }),
+                    account_keys: keys,
+                    recent_blockhash: vec![0u8; 32],
+                    instructions: vec![CompiledInstruction {
+                        program_id_index: 1,
+                        accounts: acc_idx,
+                        data,
+                    }],
+                    versioned: false,
+                    address_table_lookups: vec![],
+                }),
+            }),
+            meta: Some(TransactionStatusMeta::default()),
+        }
+    }
+
+    #[test]
+    fn buy_decode_resolves_canonical_mints() {
+        let pool = [0x01; 32];
+        let user = [0x02; 32];
+        let global_config = [0x03; 32];
+        let base_mint = [0x04; 32];
+        let quote_mint = [0x05; 32];
+        let user_base_ta = [0x06; 32];
+        let user_quote_ta = [0x07; 32];
+        let pool_base_ta = [0x08; 32];
+        let pool_quote_ta = [0x09; 32];
+        let protocol_fee_recipient = [0x0a; 32];
+        let protocol_fee_recipient_ta = [0x0b; 32];
+
+        let tx = make_tx(
+            BUY_DISC,
+            buy_body(),
+            &[
+                pool,
+                user,
+                global_config,
+                base_mint,
+                quote_mint,
+                user_base_ta,
+                user_quote_ta,
+                pool_base_ta,
+                pool_quote_ta,
+                protocol_fee_recipient,
+                protocol_fee_recipient_ta,
+            ],
+        );
+        let ix = tx.walk_instructions().next().unwrap();
+        let trade = decode_trade_instruction(&ix).expect("buy instruction must decode");
+
+        assert_eq!(trade.pool, pool.to_vec());
+        assert_eq!(trade.base_mint, base_mint.to_vec(), "base_mint must come from accounts[3], not [4]");
+        assert_eq!(trade.quote_mint, quote_mint.to_vec(), "quote_mint must come from accounts[4], not [5]");
+
+        // Regression: the previous adapter read accounts[4]/[5] which is
+        // exactly (quote_mint, user_base_token_account). Make sure neither
+        // slot leaks the user's TA back in.
+        assert_ne!(trade.base_mint, user_base_ta.to_vec());
+        assert_ne!(trade.quote_mint, user_base_ta.to_vec());
+    }
+
+    #[test]
+    fn sell_decode_uses_same_layout_as_buy() {
+        let pool = [0x21; 32];
+        let user = [0x22; 32];
+        let global_config = [0x23; 32];
+        let base_mint = [0x24; 32];
+        let quote_mint = [0x25; 32];
+        let accounts: Vec<[u8; 32]> = vec![pool, user, global_config, base_mint, quote_mint]
+            .into_iter()
+            .chain((6u8..12u8).map(|i| [i; 32]))
+            .collect();
+
+        let tx = make_tx(SELL_DISC, sell_body(), &accounts);
+        let ix = tx.walk_instructions().next().unwrap();
+        let trade = decode_trade_instruction(&ix).expect("sell instruction must decode");
+
+        assert_eq!(trade.pool, pool.to_vec());
+        assert_eq!(trade.base_mint, base_mint.to_vec());
+        assert_eq!(trade.quote_mint, quote_mint.to_vec());
     }
 }

--- a/dex-swaps/src/raydium_amm_v4.rs
+++ b/dex-swaps/src/raydium_amm_v4.rs
@@ -229,6 +229,9 @@ mod tests {
     /// 18 accounts in post-fork IDL order.
     fn make_post_fork_accounts() -> ([[u8; 32]; 18], usize, usize) {
         // (accounts, pool_coin_account_keys_index, pool_pc_account_keys_index)
+        // Comments below mirror the field names in `SwapBaseAccounts`; the
+        // `uer_*` spelling is a typo carried over verbatim from the canonical
+        // Raydium AMM v4 IDL (`uerSourceTokenAccount` / `uerDestinationTokenAccount`).
         let accs: [[u8; 32]; 18] = [
             [0x00; 32], // token_program
             [0x01; 32], // amm
@@ -245,8 +248,8 @@ mod tests {
             [0x0c; 32], // serum_coin_vault_account
             [0x0d; 32], // serum_pc_vault_account
             [0x0e; 32], // serum_vault_signer
-            [0x0f; 32], // uer_source_token_account
-            [0x10; 32], // uer_destination_token_account
+            [0x0f; 32], // uer_source_token_account (sic — IDL typo for "user")
+            [0x10; 32], // uer_destination_token_account (sic — IDL typo for "user")
             [0x11; 32], // user_source_owner
         ];
         // make_tx prepends fee_payer (0) and program (1) — instruction account
@@ -298,8 +301,8 @@ mod tests {
             [0x0c; 32], // serum_coin_vault
             [0x0d; 32], // serum_pc_vault
             [0x0e; 32], // serum_vault_signer
-            [0x0f; 32], // uer_source_token_account
-            [0x10; 32], // uer_destination_token_account
+            [0x0f; 32], // uer_source_token_account (sic — IDL typo for "user")
+            [0x10; 32], // uer_destination_token_account (sic — IDL typo for "user")
             [0x11; 32], // user_source_owner
         ];
         let coin_key_idx = 4 + 2; // post fee_payer + program shift

--- a/dex-swaps/src/raydium_amm_v4.rs
+++ b/dex-swaps/src/raydium_amm_v4.rs
@@ -4,6 +4,7 @@ use substreams_solana::block_view::InstructionView;
 use substreams_solana_idls::raydium;
 
 use crate::logs::{scoped_program_log, ProgramLog};
+use crate::token_mints::TokenMintLookup;
 
 pub(crate) struct State {
     pending: Vec<InstructionSwap>,
@@ -20,8 +21,8 @@ impl State {
         }
     }
 
-    pub(crate) fn handle_instruction(&mut self, ix: &InstructionView) {
-        if let Some(swap) = decode_instruction(ix) {
+    pub(crate) fn handle_instruction(&mut self, ix: &InstructionView, token_mints: &TokenMintLookup) {
+        if let Some(swap) = decode_instruction(ix, Some(token_mints)) {
             self.pending.push(swap);
         }
     }
@@ -37,11 +38,29 @@ impl State {
         let instruction = self.pending.get(self.next_index)?;
         self.next_index += 1;
 
-        let is_pc_to_coin = log.direction == 2;
-        let (input_mint, output_mint) = if is_pc_to_coin {
-            (instruction.amm_pc_vault.clone(), instruction.amm_coin_vault.clone())
+        // The swap instructions only carry the pool's *vaults* in their
+        // account list — not the mints. We resolved them in
+        // `handle_instruction` via `TokenMintLookup`. If the lookup missed
+        // (no matching pre/post token balance for that vault), skip emitting
+        // this row but keep the sequential alignment between pending
+        // instructions and logs intact for any subsequent V4 swaps.
+        let coin_mint = instruction.coin_mint.clone()?;
+        let pc_mint = instruction.pc_mint.clone()?;
+
+        // Per canonical Raydium AMM v4 source (`math.rs::SwapDirection`):
+        //   PC2Coin = 1  (user gave pc, got coin → input=pc, output=coin)
+        //   Coin2PC = 2  (user gave coin, got pc → input=coin, output=pc)
+        // Pre-fix the conditional was inverted (`is_pc_to_coin = direction == 2`).
+        // The bug was masked because vaults — not real mints — were stored,
+        // so the swapped labels were equally "wrong" either way. Fixing the
+        // vault→mint resolution exposes the inversion, so we correct both
+        // here.
+        let (input_mint, output_mint) = if log.direction == 2 {
+            // Coin2PC
+            (coin_mint, pc_mint)
         } else {
-            (instruction.amm_coin_vault.clone(), instruction.amm_pc_vault.clone())
+            // PC2Coin (and any other value defaults to the same orientation)
+            (pc_mint, coin_mint)
         };
 
         Some(pb::Swap {
@@ -59,12 +78,19 @@ impl State {
     }
 }
 
+#[cfg_attr(test, derive(Clone))]
 struct InstructionSwap {
     stack_height: u32,
     amm: Vec<u8>,
-    amm_coin_vault: Vec<u8>,
-    amm_pc_vault: Vec<u8>,
     user_source_owner: Vec<u8>,
+    /// Coin-side mint resolved from `pool_coin_token_account` via
+    /// `TokenMintLookup`. `None` when the lookup missed (e.g. the tx's
+    /// pre/post token balances didn't reference this vault). The placeholder
+    /// is kept so `handle_log` can still match logs to instructions by
+    /// sequential index — the row is just dropped at emit time.
+    coin_mint: Option<Vec<u8>>,
+    /// Pc-side mint resolved from `pool_pc_token_account`. See `coin_mint`.
+    pc_mint: Option<Vec<u8>>,
 }
 
 struct LogSwap {
@@ -74,10 +100,12 @@ struct LogSwap {
 }
 
 pub(crate) fn extract_pool(ix: &InstructionView) -> Option<Vec<u8>> {
-    decode_instruction(ix).map(|s| s.amm)
+    // `routed_pool::Tracker::observe` only needs the pool address; mints are
+    // resolved later in `handle_instruction` when `TokenMintLookup` is in scope.
+    decode_instruction(ix, None).map(|s| s.amm)
 }
 
-fn decode_instruction(ix: &InstructionView) -> Option<InstructionSwap> {
+fn decode_instruction(ix: &InstructionView, token_mints: Option<&TokenMintLookup>) -> Option<InstructionSwap> {
     let program_id = ix.program_id().0;
     if program_id != &raydium::amm::v4::PROGRAM_ID {
         return None;
@@ -86,17 +114,27 @@ fn decode_instruction(ix: &InstructionView) -> Option<InstructionSwap> {
     match raydium::amm::v4::instructions::unpack(ix.data()) {
         Ok(raydium::amm::v4::instructions::RaydiumV4Instruction::SwapBaseIn(_))
         | Ok(raydium::amm::v4::instructions::RaydiumV4Instruction::SwapBaseOut(_)) => {
-            let with_target_orders = ix.accounts().len() == 18;
-            let offset = if with_target_orders { 1 } else { 0 };
+            // Use the IDL-canonical typed account helper. It transparently
+            // handles both the post-fork (18-account, with `amm_target_orders`)
+            // and legacy pre-fork (17-account) layouts.
+            let accounts = raydium::amm::v4::accounts::get_swap_base_in_accounts(ix).ok()?;
+            let (coin_mint, pc_mint) = resolve_vault_mints(token_mints, accounts.pool_coin_token_account.as_ref(), accounts.pool_pc_token_account.as_ref());
             Some(InstructionSwap {
                 stack_height: ix.stack_height(),
-                amm: ix.accounts()[1].0.to_vec(),
-                amm_coin_vault: ix.accounts()[4 + offset].0.to_vec(),
-                amm_pc_vault: ix.accounts()[5 + offset].0.to_vec(),
-                user_source_owner: ix.accounts()[16 + offset].0.to_vec(),
+                amm: accounts.amm.to_bytes().to_vec(),
+                user_source_owner: accounts.user_source_owner.to_bytes().to_vec(),
+                coin_mint,
+                pc_mint,
             })
         }
         _ => None,
+    }
+}
+
+fn resolve_vault_mints(token_mints: Option<&TokenMintLookup>, coin_vault: &[u8], pc_vault: &[u8]) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
+    match token_mints {
+        Some(lookup) => (lookup.mint_for(coin_vault), lookup.mint_for(pc_vault)),
+        None => (None, None),
     }
 }
 
@@ -114,5 +152,182 @@ fn parse_log_data(log_message: &str) -> Option<LogSwap> {
             amount_out: event.amount_out,
         }),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use substreams_solana::base58;
+    use substreams_solana::pb::sf::solana::r#type::v1::{
+        CompiledInstruction, ConfirmedTransaction, Message, MessageHeader, TokenBalance, Transaction,
+        TransactionStatusMeta, UiTokenAmount,
+    };
+
+    /// SwapBaseIn discriminator (single byte for V4).
+    const SWAP_BASE_IN_DISC: u8 = 9;
+
+    /// Borsh-encoded SwapBaseIn payload (amounts irrelevant for these tests).
+    fn swap_body() -> Vec<u8> {
+        let mut b = vec![SWAP_BASE_IN_DISC];
+        b.extend_from_slice(&0u64.to_le_bytes()); // amount_in
+        b.extend_from_slice(&0u64.to_le_bytes()); // minimum_amount_out
+        b
+    }
+
+    /// Build a ConfirmedTransaction with one Raydium AMM v4 instruction.
+    /// `accounts` must be the per-instruction accounts in IDL order.
+    /// `token_balances` populates pre_token_balances so `TokenMintLookup`
+    /// can resolve vault → mint.
+    fn make_tx(accounts: &[[u8; 32]], token_balances: &[(u32, [u8; 32])]) -> ConfirmedTransaction {
+        let fee_payer = [0xfe; 32];
+        let program = raydium::amm::v4::PROGRAM_ID;
+        let mut keys: Vec<Vec<u8>> = vec![fee_payer.to_vec(), program.to_vec()];
+        let mut acc_idx: Vec<u8> = Vec::new();
+        for (i, a) in accounts.iter().enumerate() {
+            keys.push(a.to_vec());
+            acc_idx.push((i + 2) as u8);
+        }
+        let pre_token_balances = token_balances
+            .iter()
+            .map(|(idx, mint)| TokenBalance {
+                account_index: *idx,
+                mint: base58::encode(mint),
+                owner: "".to_string(),
+                program_id: "".to_string(),
+                ui_token_amount: Some(UiTokenAmount::default()),
+            })
+            .collect();
+
+        ConfirmedTransaction {
+            transaction: Some(Transaction {
+                signatures: vec![vec![0u8; 64]],
+                message: Some(Message {
+                    header: Some(MessageHeader {
+                        num_required_signatures: 1,
+                        num_readonly_signed_accounts: 0,
+                        num_readonly_unsigned_accounts: 0,
+                    }),
+                    account_keys: keys,
+                    recent_blockhash: vec![0u8; 32],
+                    instructions: vec![CompiledInstruction {
+                        program_id_index: 1,
+                        accounts: acc_idx,
+                        data: swap_body(),
+                    }],
+                    versioned: false,
+                    address_table_lookups: vec![],
+                }),
+            }),
+            meta: Some(TransactionStatusMeta {
+                pre_token_balances,
+                ..Default::default()
+            }),
+        }
+    }
+
+    /// 18 accounts in post-fork IDL order.
+    fn make_post_fork_accounts() -> ([[u8; 32]; 18], usize, usize) {
+        // (accounts, pool_coin_account_keys_index, pool_pc_account_keys_index)
+        let accs: [[u8; 32]; 18] = [
+            [0x00; 32], // token_program
+            [0x01; 32], // amm
+            [0x02; 32], // amm_authority
+            [0x03; 32], // amm_open_orders
+            [0x04; 32], // amm_target_orders (post-fork only)
+            [0x05; 32], // pool_coin_token_account ← VAULT
+            [0x06; 32], // pool_pc_token_account ← VAULT
+            [0x07; 32], // serum_program
+            [0x08; 32], // serum_market
+            [0x09; 32], // serum_bids
+            [0x0a; 32], // serum_asks
+            [0x0b; 32], // serum_event_queue
+            [0x0c; 32], // serum_coin_vault_account
+            [0x0d; 32], // serum_pc_vault_account
+            [0x0e; 32], // serum_vault_signer
+            [0x0f; 32], // uer_source_token_account
+            [0x10; 32], // uer_destination_token_account
+            [0x11; 32], // user_source_owner
+        ];
+        // make_tx prepends fee_payer (0) and program (1) — instruction account
+        // index N lives at account_keys[N + 2].
+        (accs, 5 + 2, 6 + 2)
+    }
+
+    #[test]
+    fn post_fork_swap_resolves_vaults_to_mints() {
+        let (accounts, coin_key_idx, pc_key_idx) = make_post_fork_accounts();
+        // The actual mints we expect — distinct from the vaults to prove
+        // resolution actually happened.
+        let coin_mint = [0xaa; 32];
+        let pc_mint = [0xbb; 32];
+
+        let tx = make_tx(&accounts, &[(coin_key_idx as u32, coin_mint), (pc_key_idx as u32, pc_mint)]);
+        let meta = tx.meta.as_ref().unwrap();
+        let mints = TokenMintLookup::new(&tx, meta);
+        let ix = tx.walk_instructions().next().unwrap();
+
+        let swap = decode_instruction(&ix, Some(&mints)).expect("decoder must yield InstructionSwap");
+        assert_eq!(swap.coin_mint.as_deref(), Some(coin_mint.as_slice()));
+        assert_eq!(swap.pc_mint.as_deref(), Some(pc_mint.as_slice()));
+        assert_eq!(swap.amm, accounts[1].to_vec());
+
+        // Regression: the vault accounts themselves must not appear in the mint
+        // slots. Pre-fix, the adapter wrote `accounts[5]` / `accounts[6]`
+        // directly as `input_mint` / `output_mint`.
+        assert_ne!(swap.coin_mint.as_deref(), Some(accounts[5].as_slice()));
+        assert_ne!(swap.pc_mint.as_deref(), Some(accounts[6].as_slice()));
+    }
+
+    #[test]
+    fn legacy_pre_fork_swap_resolves_vaults_to_mints() {
+        // Pre-fork pools have 17 accounts (no amm_target_orders). Pool vaults
+        // shift down: pool_coin_token_account at index 4, pool_pc at index 5.
+        let accounts: [[u8; 32]; 17] = [
+            [0x00; 32], // token_program
+            [0x01; 32], // amm
+            [0x02; 32], // amm_authority
+            [0x03; 32], // amm_open_orders
+            [0x05; 32], // pool_coin_token_account (was index 5, now 4)
+            [0x06; 32], // pool_pc_token_account (was 6, now 5)
+            [0x07; 32], // serum_program
+            [0x08; 32], // serum_market
+            [0x09; 32], // serum_bids
+            [0x0a; 32], // serum_asks
+            [0x0b; 32], // serum_event_queue
+            [0x0c; 32], // serum_coin_vault
+            [0x0d; 32], // serum_pc_vault
+            [0x0e; 32], // serum_vault_signer
+            [0x0f; 32], // uer_source_token_account
+            [0x10; 32], // uer_destination_token_account
+            [0x11; 32], // user_source_owner
+        ];
+        let coin_key_idx = 4 + 2; // post fee_payer + program shift
+        let pc_key_idx = 5 + 2;
+        let coin_mint = [0xaa; 32];
+        let pc_mint = [0xbb; 32];
+
+        let tx = make_tx(&accounts, &[(coin_key_idx as u32, coin_mint), (pc_key_idx as u32, pc_mint)]);
+        let meta = tx.meta.as_ref().unwrap();
+        let mints = TokenMintLookup::new(&tx, meta);
+        let ix = tx.walk_instructions().next().unwrap();
+
+        let swap = decode_instruction(&ix, Some(&mints)).expect("legacy decoder must yield InstructionSwap");
+        assert_eq!(swap.coin_mint.as_deref(), Some(coin_mint.as_slice()));
+        assert_eq!(swap.pc_mint.as_deref(), Some(pc_mint.as_slice()));
+    }
+
+    #[test]
+    fn unresolved_lookup_keeps_placeholder_with_none_mints() {
+        // No pre/post token balances → mint_for misses for both vaults.
+        let (accounts, _, _) = make_post_fork_accounts();
+        let tx = make_tx(&accounts, &[]);
+        let meta = tx.meta.as_ref().unwrap();
+        let mints = TokenMintLookup::new(&tx, meta);
+        let ix = tx.walk_instructions().next().unwrap();
+
+        let swap = decode_instruction(&ix, Some(&mints)).expect("placeholder must still emit");
+        assert!(swap.coin_mint.is_none(), "vault must not leak into coin_mint slot when lookup misses");
+        assert!(swap.pc_mint.is_none(), "vault must not leak into pc_mint slot when lookup misses");
     }
 }


### PR DESCRIPTION
## Summary

Three independent bugs each corrupt the `(input_mint, output_mint)` columns for some swap rows. The first three are unrelated; the fourth was masked by the second and surfaces once the second is fixed.

Targets the `svm-dex v0.5.0` release. Depends on `substreams-solana-idls` v1.2.0 (typed account helpers + variable-layout `SwapBaseAccounts`). The workspace dep is currently pinned at the v1.2.0 candidate branch — flip back to a tag once the IDL PR lands.

## Bugs fixed

### `pumpfun_amm.rs` — off-by-one accounts

The decoder hand-indexed `instruction.accounts().get(4)` and `.get(5)` for `base_mint` and `quote_mint`. Per the canonical PumpSwap IDL — and as already implemented correctly elsewhere in this repo — those indices are `[3]` and `[4]`. Account 5 is `user_base_token_account`, a per-user value that leaked into the `mint` slot and produced a long tail of fake `(mint0, mint1)` pairs per pool downstream.

Replaced with `pumpswap::accounts::TradeAccounts::try_from(ix)` from the typed helper added in the IDL crate. Includes regression tests asserting `user_base_token_account` cannot end up in either mint slot.

### `raydium_amm_v4.rs` — vault address stored as mint

`SwapBaseIn` / `SwapBaseOut` only carry pool vaults (`pool_coin_token_account`, `pool_pc_token_account`) in their account lists per the canonical IDL — the mints themselves are not exposed by the instruction. The existing decoder wrote those vault token-account addresses straight into the `input_mint` / `output_mint` fields of the output proto.

Vault → mint resolution via `TokenMintLookup` (the same pattern already used by `raydium_clmm.rs`, `byreal.rs`, `pancakeswap.rs`, `meteora_amm.rs`). The instruction handler now stores the vaults transiently and resolves them from the transaction's pre/post token balances at log-emit time. When the lookup misses the row is dropped, but the log/instruction sequential alignment is preserved via a `None`-placeholder so subsequent V4 swaps in the same tx still match correctly.

### `raydium_amm_v4.rs` — direction-byte inversion

`is_pc_to_coin = log.direction == 2` is inverted vs the canonical Raydium `SwapDirection` enum (`PC2Coin = 1, Coin2PC = 2`). The boolean was being computed as if `2 == PC2Coin`. Result: every Raydium AMM v4 row historically had reversed `(input_mint, output_mint)`.

This bug was masked by the vault-as-mint issue above — when both labels were vaults, the swap was equally "wrong" either way. Fixing the vault → mint resolution exposes it.

The conditional now matches the canonical enum directly (`if direction == 2 { (coin_mint, pc_mint) } else { (pc_mint, coin_mint) }`), matching the user-perspective semantics of `Coin2PC` (paid coin, got pc).

### `orca_whirlpool.rs` legacy `swap` — vault address stored as mint

Same shape as the Raydium AMM v4 case. Legacy `swap` only carries `token_vault_a` / `token_vault_b` per the canonical Whirlpool IDL — `swap_v2` is the variant that exposes `token_mint_a` / `token_mint_b` directly. The existing decoder wrote vault addresses into the `mint_a` / `mint_b` slots for legacy swaps; SwapV2 was already correct.

Fix: `TokenMintLookup` resolution for the legacy variant, mirroring the pattern above. SwapV2 path unchanged.

## Migration

Data-shape change for `pumpfun_amm`, `raydium_amm_v4`, `orca_whirlpool` (legacy `swap`) — the `(input_mint, output_mint)` columns will hold real mint addresses instead of vault / per-user-TA addresses. Sink to a fresh database; existing rows are not migration-compatible.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)