### PR TITLE
fix(dex-swaps): match Darklake Settle event for realised swaps

### DIFF
--- a/dex-swaps/src/darklake.rs
+++ b/dex-swaps/src/darklake.rs
@@ -1,34 +1,16 @@
 use common::solana::parse_program_data;
 use proto::pb::dex::swaps::v1 as pb;
-use substreams_solana::block_view::InstructionView;
 use substreams_solana_idls::darklake;
 
 use crate::logs::{scoped_program_log, ProgramLog};
 
 pub(crate) struct State {
-    pending: Vec<bool>,
-    next_index: usize,
     is_invoked: bool,
 }
 
 impl State {
     pub(crate) fn new() -> Self {
-        Self {
-            pending: Vec::new(),
-            next_index: 0,
-            is_invoked: false,
-        }
-    }
-
-    pub(crate) fn handle_instruction(&mut self, ix: &InstructionView) {
-        let program_id = ix.program_id().0;
-        if program_id != &darklake::PROGRAM_ID {
-            return;
-        }
-
-        if let Ok(darklake::instructions::DarklakeInstruction::Swap(event)) = darklake::instructions::unpack(ix.data()) {
-            self.pending.push(event.is_swap_x_to_y);
-        }
+        Self { is_invoked: false }
     }
 
     pub(crate) fn handle_log(&mut self, log_message: &str) -> Option<pb::Swap> {
@@ -39,12 +21,19 @@ impl State {
         };
 
         let data = parse_program_data(log_message)?;
+        // Darklake is a commit-reveal AMM: the `Swap` instruction deposits
+        // tokens with a commitment hash (intent), and a relayer later calls
+        // `Settle` with a zk proof to realise the trade. Cancellation and
+        // slashing paths never produce a `SettleEvent`, so matching only
+        // `SettleEvent` gives us exactly the realised swaps.
         let event = match darklake::events::unpack_event(data.as_slice()) {
-            Ok(darklake::events::DarklakeEvent::Swap(event)) => event,
+            Ok(darklake::events::DarklakeEvent::Settle(event)) => event,
             _ => return None,
         };
-        let is_x_to_y = *self.pending.get(self.next_index)?;
-        self.next_index += 1;
+
+        // `direction` is the borsh-serialised `is_swap_x_to_y: bool`
+        // (1 = x → y, 0 = y → x).
+        let is_x_to_y = event.direction == 1;
         let (input_mint, output_mint) = if is_x_to_y {
             (event.token_mint_x.to_bytes().to_vec(), event.token_mint_y.to_bytes().to_vec())
         } else {
@@ -59,13 +48,55 @@ impl State {
             amm_pool: darklake::PROGRAM_ID.to_vec(),
             user: event.trader.to_bytes().to_vec(),
             input_mint,
-            // Darklake emits both intent (`amount_in`/`amount_out`) and
-            // realised post-fee values (`actual_amount_in`/`actual_amount_out`).
-            // Use the actuals so charts and volume reflect what users
-            // actually paid/received. See substreams-svm#210 item 4.
             input_amount: event.actual_amount_in,
             output_mint,
             output_amount: event.actual_amount_out,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // On-chain Darklake Settle event captured from mainnet tx
+    // 56BDsUWsCyE4sSAkAzTktZdi2RMwy1eo7TxNdkUKRUkWZL4oBQtjD4bvJwteBtAG9GaHFRi5beHsJtzR6MyFBQke
+    // (wSOL → token, direction = 1 = x → y, 10_000_000 → 1_256_182).
+    const SETTLE_LOG: &str = "Program data: rFhWSePRzDjbB8sJiZk3v19TqE6qKNp5MtRG2db85Fba1w4g65weItsHywmJmTe/X1OoTqoo2nky1EbZ1vzkVtrXDiDrnB4iAUoDthcAAAAAqGEAAAAAAAAw05cAAAAAAPYqEwAAAAAAgJaYAAAAAABA2EEAAAAAAIgTAAAAAAAAYEsnAAAAAAD2KhMAAAAAAIeaVq4EAAAAzYEjlwAAAACpI7esBAAAAGCBApcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAi3oUBAAAAANDLHgAAAAAAU4fbQL5xIWf9blCh5sD10YfqZAvzAnPwplgcRJuxQvf3Zm039PDKro9dj6e3WMEQm9Agfsqkhmo7/XPs1aowdm1n24wGIIi6EBnjbMTjANsUf1jgSBNts4SDaolOgPOrBpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAHG+nrzvtutOj1l82qryXQxsbvkwtL24OR8pgIDRS9dYRMAAABqY3YwLjIuMCx3aGFsZS1zdWl0AAAAAA==";
+    const INVOKE_LOG: &str = "Program darkr3FB87qAZmgLwKov6Hk9Yiah5UT4rUYu8Zhthw1 invoke [1]";
+
+    #[test]
+    fn settle_event_emits_swap_with_realised_amounts() {
+        let mut state = State::new();
+        assert!(state.handle_log(INVOKE_LOG).is_none(), "invoke is a header, not a swap");
+        let swap = state
+            .handle_log(SETTLE_LOG)
+            .expect("Settle event should decode into a swap");
+
+        assert_eq!(swap.protocol, pb::Protocol::Darklake as i32);
+        assert_eq!(swap.input_amount, 10_000_000);
+        assert_eq!(swap.output_amount, 1_256_182);
+        // direction=1 -> input = token_mint_x = wSOL (So11111111111111111111111111111111111111111)
+        assert_eq!(swap.input_mint, crate::SOL_MINT.to_vec());
+        // trader db07cb09899937bf5f53a84eaa28da7932d446d9d6fce456dad70e20eb9c1e22
+        assert_eq!(
+            swap.user,
+            [
+                0xdb, 0x07, 0xcb, 0x09, 0x89, 0x99, 0x37, 0xbf, 0x5f, 0x53, 0xa8, 0x4e, 0xaa, 0x28, 0xda, 0x79,
+                0x32, 0xd4, 0x46, 0xd9, 0xd6, 0xfc, 0xe4, 0x56, 0xda, 0xd7, 0x0e, 0x20, 0xeb, 0x9c, 0x1e, 0x22,
+            ]
+        );
+    }
+
+    #[test]
+    fn swap_intent_event_is_ignored() {
+        // Real SwapEvent (intent) from mainnet tx
+        // 4KpMwB5n8u3jmzcTTUD7NJMbNC2SJA9hURa2THE9mFqSJUGqC6UYinCGpkK9qZ8FdxH6V4fkqHuJWAfkmhTtQFJn —
+        // only realised SettleEvents should produce swaps.
+        let swap_event_log = "Program data: UWzjvs3QCsQLE/3EW00Z3UD/couPlpXnLjrnbc03ZEIcKMvzILA+OAFLE74XAAAAALqDAAAAAAAA3UEAAAAAAAAjZWYAAAAAAF0uDQAAAAAA3ehmAAAAAADI60EAAAAAAF0uDQAAAAAAlOqXAAAAAAAbZSEAAAAAANMIWgAAAAAALnITAAAAAAAzBz0AAAAAAF0uDQAAAAAA3ehmAAAAAAAAAAAAAAAAAI7aAAAAAAAAkMQAAAAAAADjBXni+/SMviQjZ16c3j/3bO0rtEbrozGeXFo12dr3SU55lnjhWzDrD1x9AiUrbwXOO8hFUaKgZYCIx+JuuPuHNJAPPbJjColiTw3TN8i+TYy3K/EcIbh3z6DzXqHNu9sGm4hX/quBhPtof2NGGMA12sQ53BrrO1WYoPAAAAAAAc4BDmCv7bInF71jGS9UFFo/llozu4LSxwKess4eIIJkAAAAAA==";
+        let mut state = State::new();
+        assert!(state.handle_log(INVOKE_LOG).is_none());
+        assert!(state.handle_log(swap_event_log).is_none(),
+                "SwapEvent (intent) must not be matched");
     }
 }

--- a/dex-swaps/src/lib.rs
+++ b/dex-swaps/src/lib.rs
@@ -70,7 +70,6 @@ fn process_transaction(tx: ConfirmedTransaction) -> Option<pb::Transaction> {
             swaps.push(swap);
         }
         byreal_state.handle_instruction(&instruction, &token_mints);
-        darklake_state.handle_instruction(&instruction);
         if let Some(swap) = pumpfun::handle_instruction(&mut pumpfun_pending, &instruction) {
             swaps.push(swap);
         }


### PR DESCRIPTION
## Summary

- Darklake is a commit-reveal AMM. The `Swap` instruction deposits tokens and records a commitment; a relayer later calls `Settle` (with zk proof) to realise the trade. Cancel/Slash paths finalise without a fill.
- The previous adapter matched `SwapEvent` (intent), which reported cancellations as completed swaps and surfaced pre-settle amounts instead of realised in/out values.
- Switch the adapter to `SettleEvent` matching so each emitted row is a realised on-chain fill, with `actual_amount_in` / `actual_amount_out` reflecting what the trader paid and received.

The `Swap` instruction tracking (and the per-instruction `pending` direction queue) is no longer needed — `SettleEvent.direction` carries the borsh-serialised `is_swap_x_to_y` bool (1 = x → y).

Two regression tests added using real on-chain log payloads:
- a mainnet `SettleEvent` log decodes to the expected realised swap fields,
- a mainnet `SwapEvent` (intent) log produces no row.

End-to-end SPKG run against mainnet confirms realised Settle txs are now captured and intent-only Swap txs are correctly skipped.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)