### PR TITLE
fix(dex-swaps): match Meteora DAAM EvtSwap2 to restore swap emission

### DIFF
--- a/dex-swaps/src/meteora_daam.rs
+++ b/dex-swaps/src/meteora_daam.rs
@@ -84,6 +84,15 @@ fn decode_swap_event(ix: &InstructionView) -> Option<SwapEvent> {
             output_amount: event.swap_result.output_amount,
             trade_direction: event.trade_direction,
         }),
+        // Since the cp-amm upgrade on 2025-12-26 both `swap` and `swap2`
+        // emit `EvtSwap2` instead of `EvtSwap`. `included_transfer_fee_amount_in`
+        // mirrors what the user paid (pre-pool fees) and is the analogue of
+        // the legacy `actual_amount_in`.
+        Ok(daam::anchor_cpi_event::MeteoraDammAnchorCpiEvent::EvtSwap2(event)) => Some(SwapEvent {
+            amount_in: event.included_transfer_fee_amount_in,
+            output_amount: event.swap_result.output_amount,
+            trade_direction: event.trade_direction,
+        }),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

- The cp-amm program deprecated `EvtSwap` in favour of `EvtSwap2` on 2025-12-26; the legacy `swap` and the new `swap2` instructions now both emit `EvtSwap2`.
- The adapter previously matched only `EvtSwap`, so Meteora DAAM emission dropped to zero on that date.
- Add an `EvtSwap2` match arm in `decode_swap_event`, mapping `included_transfer_fee_amount_in` (analogue of the legacy `actual_amount_in`) and `swap_result.output_amount` onto the normalised swap row. The `EvtSwap` arm stays so historical payloads continue to decode.

The workspace `substreams-solana-idls` dependency is repinned to a commit carrying both the `EvtSwap2` event (idls#146) and the CLMM `SwapEvent` tolerance fix (idls#145). Once both IDL PRs merge and a release tag is cut, this dependency will flip back to a tag pin.

End-to-end SPKG run against mainnet confirms DAAM swap emission is restored on post-upgrade slots that previously yielded zero rows.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)