### PR TITLE
refactor(dex-swaps): hold meteora pending swaps as FIFO queues

### DIFF
--- a/dex-swaps/src/lib.rs
+++ b/dex-swaps/src/lib.rs
@@ -22,6 +22,8 @@ mod routed_pool;
 mod spl_token_swap;
 mod token_mints;
 
+use std::collections::VecDeque;
+
 use common::solana::{get_fee_payer, get_signers};
 use proto::pb::dex::swaps::v1 as pb;
 use substreams::{errors::Error, log};
@@ -51,8 +53,8 @@ fn process_transaction(tx: ConfirmedTransaction) -> Option<pb::Transaction> {
     let mut pumpfun_pending = None;
     let mut pumpfun_amm_pending = None;
     let mut meteora_amm_state = meteora_amm::State::new();
-    let mut meteora_daam_pending = None;
-    let mut meteora_dlmm_pending = None;
+    let mut meteora_daam_pending: VecDeque<meteora_daam::PendingSwap> = VecDeque::new();
+    let mut meteora_dlmm_pending: VecDeque<meteora_dlmm::PendingSwap> = VecDeque::new();
     let mut moonshot_state = moonshot::State::new();
     let mut okx_state = okx::State::new();
     let mut pancakeswap_state = pancakeswap::State::new();

--- a/dex-swaps/src/meteora_daam.rs
+++ b/dex-swaps/src/meteora_daam.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use proto::pb::dex::swaps::v1 as pb;
 use substreams_solana::block_view::InstructionView;
 use substreams_solana_idls::meteora::daam;
@@ -16,19 +18,22 @@ struct SwapEvent {
     trade_direction: u8,
 }
 
-pub(crate) fn handle_instruction(pending_swap: &mut Option<PendingSwap>, instruction: &InstructionView) -> Option<pb::Swap> {
+/// Hold pending swaps as a FIFO queue. See `meteora_dlmm` for the rationale —
+/// same hazard applies: a stale `Option<PendingSwap>` could be overwritten by
+/// a second swap instruction before the first's anchor-CPI event landed.
+pub(crate) fn handle_instruction(pending: &mut VecDeque<PendingSwap>, instruction: &InstructionView) -> Option<pb::Swap> {
     let program_id = instruction.program_id().0;
     if program_id != &daam::PROGRAM_ID {
         return None;
     }
 
     if let Some(swap) = decode_swap_instruction(instruction) {
-        *pending_swap = Some(swap);
+        pending.push_back(swap);
         return None;
     }
 
     let event = decode_swap_event(instruction)?;
-    let swap = pending_swap.take()?;
+    let swap = pending.pop_front()?;
     let (input_mint, output_mint) = if event.trade_direction == 0 {
         (swap.token_a_mint.clone(), swap.token_b_mint.clone())
     } else {

--- a/dex-swaps/src/meteora_dlmm.rs
+++ b/dex-swaps/src/meteora_dlmm.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use proto::pb::dex::swaps::v1 as pb;
 use substreams_solana::block_view::InstructionView;
 use substreams_solana_idls::meteora::dlmm;
@@ -15,19 +17,26 @@ struct SwapEvent {
     swap_for_y: bool,
 }
 
-pub(crate) fn handle_instruction(pending_swap: &mut Option<PendingSwap>, instruction: &InstructionView) -> Option<pb::Swap> {
+/// Hold pending swaps as a FIFO queue rather than a single `Option` slot. The
+/// queue is consumed front-to-back in `walk_instructions` order, which on
+/// chain matches the order in which each swap's anchor-CPI `Swap` event
+/// fires after its own instruction. The single-slot variant could silently
+/// lose the first swap's context if a second swap instruction overwrote
+/// `pending` before the first event arrived (e.g. on a future anchor-CPI
+/// event variant the adapter doesn't yet match).
+pub(crate) fn handle_instruction(pending: &mut VecDeque<PendingSwap>, instruction: &InstructionView) -> Option<pb::Swap> {
     let program_id = instruction.program_id().0;
     if program_id != &dlmm::PROGRAM_ID {
         return None;
     }
 
     if let Some(swap) = decode_swap_instruction(instruction) {
-        *pending_swap = Some(swap);
+        pending.push_back(swap);
         return None;
     }
 
     let event = decode_swap_event(instruction)?;
-    let swap = pending_swap.take()?;
+    let swap = pending.pop_front()?;
     let (input_mint, output_mint) = if event.swap_for_y {
         (swap.token_x_mint.clone(), swap.token_y_mint.clone())
     } else {


### PR DESCRIPTION
## Summary

- The DAAM and DLMM adapters keep an `Option<PendingSwap>` between each swap instruction and the anchor-CPI event that follows.
- If a second swap instruction lands in the same transaction before the first's event was matched (e.g. a future event variant the adapter does not yet recognise), the second overwrites the first's pending state and the first row is silently lost.
- Replace both single-slot `Option`s with `VecDeque<PendingSwap>` queues consumed front-to-back in `walk_instructions` depth-first order, which matches the order in which each swap's anchor-CPI event fires after its own instruction.

The happy path is unchanged: a single swap pushes one entry, the matching event pops it.

End-to-end SPKG run against mainnet shows identical DLMM emission counts versus the prior release, confirming no regression on the common case.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)